### PR TITLE
Merging feature/support-for-insmod-rmmod, resolves #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are different kernel designs due to the different ways of managing system 
 Although the Linux-based operating systems dominate the most of computing, it still carries some of the design flaws which were quite a bit of debate in the early days of Linux. For example, it has the **largest footprint** and **the most complexity** over the other types of kernels. But it's a design feature that monolithic kernels inherent to have. These kind of design issues led developers to add new features and mechanisms to the Linux kernel which other kernels don't have.
 
 Unlike the standard monolithic kernels, the Linux kernel is also **modular**, accepting **loadable kernel modules (LKM)** that typically used to add support for new *hardware* (as device drivers) and/or *filesystems*, or for adding *system calls*. Since LKMs could be loaded and unloaded to the system *at runtime*, they have the advantage of extending the kernel without rebooting and re-compiling. Thus, the kernel functionalities provided by modules would not reside in memory without being used and the related module can be unloaded in order to free memory and other resources.  
-Loadable kernel modules are located in `/lib/modules` with the `.ko` (*kernel object*) extension in Linux. While the [lsmod](https://linux.die.net/man/8/lsmod) command could be used for listing the loaded kernel modules, [modprobe](https://linux.die.net/man/8/modprobe) is used for loading or unloading a kernel module.
+Loadable kernel modules are located in `/lib/modules` with the `.ko` (*kernel object*) extension in Linux. While the [lsmod](https://linux.die.net/man/8/lsmod) command could be used for listing the loaded kernel modules, [modprobe](https://linux.die.net/man/8/modprobe) or [insmod](https://linux.die.net/man/8/insmod)/[rmmod](https://linux.die.net/man/8/rmmod) is used for loading or unloading a kernel module. insmod/rmmod are used for modules independent of modprobe and without requiring an installation to ```/lib/modules/$(uname -r)```.
 
 Here's a simple example of a Linux kernel module that prints a message when it's loaded and unloaded. The build and installation steps of the [module](https://github.com/orhun/kmon/blob/master/example/lkm_example.c) using a [Makefile](https://github.com/orhun/kmon/blob/master/example/Makefile) are shown below.
 
@@ -331,7 +331,7 @@ For adding a module to the Linux kernel, switch to load mode with one of the `+,
 The command that used for loading a module:
 
 ```
-modprobe <module_name>
+modprobe <module_name> || insmod <module_name>.ko
 ```
 
 ### Unloading a module
@@ -343,7 +343,7 @@ Use one of the `-, u, backspace` keys to remove the selected module from the Lin
 The command that used for removing a module:
 
 ```
-modprobe -r <module_name>
+modprobe -r <module_name> || rmmod <module_name>
 ```
 
 ### Blacklisting a module
@@ -370,7 +370,7 @@ Use `ctrl-r` or `alt-r` key for reloading the selected module.
 The command that used for reloading a module:
 
 ```
-modprobe -r <module_name> && modprobe <module_name>
+modprobe -r <module_name> || rmmod <module_name> && modprobe <module_name> || insmod <module_name>.ko
 ```
 
 ### Clearing the ring buffer

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -145,17 +145,46 @@ mod tests {
 	fn test_module_command() {
 		let module_command = ModuleCommand::None;
 		assert_eq!(true, module_command == ModuleCommand::None);
+
 		assert_ne!("", ModuleCommand::None.get("test").title);
 		assert_ne!("", ModuleCommand::Load.get("module").desc);
 		assert_ne!("", ModuleCommand::Unload.get("!command").cmd);
 		assert_ne!("", ModuleCommand::Blacklist.get("~").cmd);
+
+		assert_eq!(
+			"modprobe test-module || insmod test-module.ko",
+			ModuleCommand::Load.get("test-module").cmd
+		);
+		assert_eq!(
+			"insmod test-module.ko",
+			ModuleCommand::Load.get("test-module.ko").cmd
+		);
+
+		assert_eq!(
+			"modprobe -r test-module || rmmod test-module",
+			ModuleCommand::Unload.get("test-module").cmd
+		);
+		assert_eq!(
+			"modprobe -r test-module.ko || rmmod test-module.ko",
+			ModuleCommand::Unload.get("test-module.ko").cmd
+		);
+
 		assert_eq!(
 			format!(
 				"{} && {}",
-				ModuleCommand::Unload.get("x").cmd,
-				ModuleCommand::Load.get("x").cmd
+				ModuleCommand::Unload.get("test-module").cmd,
+				ModuleCommand::Load.get("test-module").cmd
 			),
-			ModuleCommand::Reload.get("x").cmd,
+			ModuleCommand::Reload.get("test-module").cmd,
+		);
+
+		assert_eq!(
+			format!(
+				"{} && {}",
+				ModuleCommand::Unload.get("test-module.ko").cmd,
+				ModuleCommand::Load.get("test-module.ko").cmd
+			),
+			ModuleCommand::Reload.get("test-module.ko").cmd,
 		);
 	}
 }

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -128,9 +128,10 @@ impl ModuleCommand {
 	 */
 	pub fn is_module_filename(module_name: &str) -> bool {
 		// todo: solve clippy::cmp-owned, this creates an owned instance just for comparison
-		module_name.len() > 2
-			&& module_name.trim()[module_name.len() - 2..module_name.len()]
-				== String::from("ko")
+		let suffix =
+			module_name.trim()[module_name.len() - 2..module_name.len()].to_string();
+
+		return module_name.len() > 2 && suffix == String::from("ko");
 	}
 
 	/**

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -128,10 +128,9 @@ impl ModuleCommand {
 	 */
 	pub fn is_module_filename(module_name: &str) -> bool {
 		// todo: solve clippy::cmp-owned, this creates an owned instance just for comparison
-		let suffix =
-			module_name.trim()[module_name.len() - 2..module_name.len()].to_string();
-
-		return module_name.len() > 2 && suffix == String::from("ko");
+		module_name.len() > 2
+			&& module_name.trim()[module_name.len() - 2..module_name.len()]
+				== String::from("ko")
 	}
 
 	/**

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -63,18 +63,23 @@ impl ModuleCommand {
 	pub fn get(self, module_name: &str) -> Command {
 		match self {
             Self::None => Command::new(String::from(""), "", format!("Module: {}", module_name), Symbol::None),
-            Self::Load => Command::new(
-				format!("modprobe {}", &module_name),
-				"modprobe: Add and remove modules from the Linux Kernel\n
-				This command inserts a module to the kernel.",
-				format!("Load: {}", module_name), Symbol::Anchor),
+
+            Self::Load => {
+                let cmd = if ! Self::is_module_filename(&module_name) { "modprobe" } else { "insmod" };
+
+                return Command::new(
+                    format!("{} {}", &cmd, &module_name),
+                    "Add and remove modules from the Linux Kernel\n
+                    This command inserts a module to the kernel.",
+                    format!("Load: {}", module_name), Symbol::Anchor);
+            },
             Self::Unload => Command::new(
-                format!("modprobe -r {}", &module_name),
-                "modprobe: Add and remove modules from the Linux Kernel
-                option: -r, --remove\n
+                format!("modprobe -r {0} || rmmod {0}", &module_name),
+                "modprobe/rmmod: Add and remove modules from the Linux Kernel
+                modprobe -r, --remove or rmmod\n
                 This option causes modprobe to remove rather than insert a module. \
                 If the modules it depends on are also unused, modprobe will try to \
-				remove them too.
+                remove them too.
                 There is usually no reason to remove modules, but some buggy \
                 modules require it. Your distribution kernel may not have been \
                 built to support removal of modules at all.",
@@ -118,6 +123,17 @@ impl ModuleCommand {
 	 */
 	pub fn is_none(self) -> bool {
 		self == Self::None
+	}
+
+	/**
+	 * Check if module name is a filename with suffix 'ko'
+	 *
+	 * @return bool
+	 */
+	pub fn is_module_filename(module_name: &str) -> bool {
+		module_name.len() > 2
+			&& module_name.trim()[module_name.len() - 2..module_name.len()]
+				== String::from("ko")
 	}
 }
 

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -64,7 +64,7 @@ impl ModuleCommand {
 		match self {
             Self::None => Command::new(String::from(""), "", format!("Module: {}", module_name), Symbol::None),
             Self::Load => Command::new(
-                Self::get_load_command(&module_name),
+                Self::get_load_commandline(&module_name),
                 "Add and remove modules from the Linux Kernel\n
                 This command inserts a module to the kernel.",
                 format!("Load: {}", module_name), Symbol::Anchor),
@@ -134,11 +134,11 @@ impl ModuleCommand {
 	}
 
 	/**
-	 * Get load command based upon module_name
+	 * Get load command line based upon module_name
 	 *
 	 * @return String
 	 */
-	pub fn get_load_command(module_name: &str) -> String {
+	pub fn get_load_commandline(module_name: &str) -> String {
 		if !Self::is_module_filename(&module_name) {
 			format!("modprobe {0} || insmod {0}.ko", &module_name)
 		} else {

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -64,7 +64,11 @@ impl ModuleCommand {
 		match self {
             Self::None => Command::new(String::from(""), "", format!("Module: {}", module_name), Symbol::None),
             Self::Load => Command::new(
-                Self::get_load_commandline(&module_name),
+                if Self::is_module_filename(&module_name) {
+					format!("insmod {}", &module_name)
+				} else {
+					format!("modprobe {0} || insmod {0}.ko", &module_name)
+				},
                 "Add and remove modules from the Linux Kernel\n
                 This command inserts a module to the kernel.",
                 format!("Load: {}", module_name), Symbol::Anchor),
@@ -130,19 +134,6 @@ impl ModuleCommand {
 		match module_name.split('.').collect::<Vec<&str>>().last() {
 			Some(v) => *v == "ko",
 			None => false,
-		}
-	}
-
-	/**
-	 * Get load command line based upon module_name
-	 *
-	 * @return String
-	 */
-	pub fn get_load_commandline(module_name: &str) -> String {
-		if !Self::is_module_filename(&module_name) {
-			format!("modprobe {0} || insmod {0}.ko", &module_name)
-		} else {
-			format!("insmod {}", &module_name)
 		}
 	}
 }

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -127,10 +127,10 @@ impl ModuleCommand {
 	 * @return bool
 	 */
 	pub fn is_module_filename(module_name: &str) -> bool {
-		// todo: solve clippy::cmp-owned, this creates an owned instance just for comparison
-		module_name.len() > 2
-			&& module_name.trim()[module_name.len() - 2..module_name.len()]
-				== String::from("ko")
+		match module_name.split('.').collect::<Vec<&str>>().last() {
+			Some(v) => *v == "ko",
+			None => false,
+		}
 	}
 
 	/**

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -4,6 +4,7 @@ use crate::style::{Style, StyledText, Symbol};
 use crate::util;
 use bytesize::ByteSize;
 use clap::ArgMatches;
+use std::path::Path;
 use std::slice::Iter;
 use tui::widgets::Text;
 
@@ -311,7 +312,11 @@ impl KernelModules<'_> {
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
 						.unwrap_or_else(|_| {
-							String::from("failed to retrieve module information")
+							if Self::is_module_loaded(&self.current_name) {
+								String::from("module information not available")
+							} else {
+								String::from("failed to retrieve module information")
+							}
 						})
 						.replace("signature: ", "signature: \n")
 						.into_boxed_str(),
@@ -373,6 +378,10 @@ impl KernelModules<'_> {
 			}
 			_ => {}
 		}
+	}
+
+	pub fn is_module_loaded(module_name: &str) -> bool {
+		Path::new(&format!("/sys/module/{}", module_name)).exists()
 	}
 }
 

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -4,7 +4,6 @@ use crate::style::{Style, StyledText, Symbol};
 use crate::util;
 use bytesize::ByteSize;
 use clap::ArgMatches;
-use std::path::Path;
 use std::slice::Iter;
 use tui::widgets::Text;
 
@@ -312,11 +311,7 @@ impl KernelModules<'_> {
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
 						.unwrap_or_else(|_| {
-							if Self::is_module_loaded(&self.current_name) {
-								String::from("module information not available")
-							} else {
-								String::from("failed to retrieve module information")
-							}
+							String::from("module information not available")
 						})
 						.replace("signature: ", "signature: \n")
 						.into_boxed_str(),
@@ -378,10 +373,6 @@ impl KernelModules<'_> {
 			}
 			_ => {}
 		}
-	}
-
-	pub fn is_module_loaded(module_name: &str) -> bool {
-		Path::new(&format!("/sys/module/{}", module_name)).exists()
 	}
 }
 


### PR DESCRIPTION
## Description
Adding support for loading and unloading modules with insmod and rmmod independent of modprobe and without dependency handling.

## Motivation and Context
The current way to load modules from within kmon is based upon modprobe. modprobe requires modules being inside /lib/modules/$(uname -r). This requirement having to install modules into that directory and update dependency tree with depmod is sometimes cumbersome. And to install some early development stage or experimental modules into the system should not be required.

## How Has This Been Tested?
Loading, Reloading and Unloading a module by filename and as well as by module name to be certain that present functionality is still working.

## Screenshots / Output (if appropriate):
none

## Types of changes 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**todo when discussed and finished**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**todo when discussed and finished**
- [x] My code follows the code style of this project.
- [x] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed. 