### PR TITLE
Add accent-color option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2020-07-31
+### Changed
+- Add accent color option to set default text color
+
 ## [1.3.5] - 2020-07-30
 ### Changed
 - Update README.md about Arch Linux packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "kmon"
-version = "1.3.5"
+version = "1.4.0"
 dependencies = [
  "bytesize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmon"
-version = "1.3.5"
+version = "1.4.0"
 description = "Linux kernel manager and activity monitor"
 authors = ["orhun <orhunparmaksiz@gmail.com>"]
 license = "GPL-3.0"

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ kmon [FLAGS] [OPTIONS] [SUBCOMMANDS]
 ### Options
 
 ```
--c, --color <COLOR>    Set the main color using hex or color name [default: darkgray]
--t, --tickrate <MS>    Set the refresh rate of the terminal [default: 250]
+-a, --accent-color <COLOR>    Set the accent color using hex or color name [default: gray]
+-c, --color <COLOR>           Set the main color using hex or color name [default: darkgray]
+-t, --tickrate <MS>           Set the refresh rate of the terminal [default: 250]
 ```
 
 ### Subcommands

--- a/src/style.rs
+++ b/src/style.rs
@@ -106,6 +106,20 @@ impl Style {
 			"lightcyan" => Color::LightCyan,
 			"white" => Color::White
 		];
+		let accent_color = match args.value_of("accent-color") {
+			Some(v) => *colors.get::<str>(&v.to_lowercase()).unwrap_or({
+				if let Ok(rgb) = Rgb::from_hex_str(&format!("#{}", v)) {
+					Box::leak(Box::new(Color::Rgb(
+						rgb.get_red() as u8,
+						rgb.get_green() as u8,
+						rgb.get_blue() as u8,
+					)))
+				} else {
+					&Color::White
+				}
+			}),
+			None => Color::White,
+		};
 		let main_color = match args.value_of("color") {
 			Some(v) => *colors.get::<str>(&v.to_lowercase()).unwrap_or({
 				if let Ok(rgb) = Rgb::from_hex_str(&format!("#{}", v)) {
@@ -121,7 +135,7 @@ impl Style {
 			None => Color::DarkGray,
 		};
 		Self {
-			default: TuiStyle::default(),
+			default: TuiStyle::default().fg(accent_color),
 			bold: TuiStyle::default().modifier(Modifier::BOLD),
 			colored: TuiStyle::default().fg(main_color),
 			unicode: Unicode::new(!args.is_present("unicode")),

--- a/src/util.rs
+++ b/src/util.rs
@@ -61,6 +61,15 @@ pub fn parse_args() -> clap::ArgMatches<'static> {
 		.usage("kmon [FLAGS] [OPTIONS] [SUBCOMMANDS]")
 		.before_help(ASCII_LOGO)
 		.arg(
+			Arg::with_name("accent-color")
+				.short("a")
+				.long("accent-color")
+				.value_name("COLOR")
+				.default_value("white")
+				.help("Set the accent color using hex or color name")
+				.takes_value(true),
+		)
+		.arg(
 			Arg::with_name("color")
 				.short("c")
 				.long("color")


### PR DESCRIPTION
## Description
Add accent-color option to set default text color. I don't have an idea how it should be called, I guess you'll have a better idea.

## Motivation and Context
What problem does it solve?
Unreadability on some themes (especially transparent ones).

## How Has This Been Tested?
By running and seeing different options.

## Screenshots / Output (if appropriate):
This is how it looks with red color passed as an argument.
![Example](https://i.imgur.com/AjOZyIl.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
