### PR TITLE
Avoid actually parsing cli during tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2020-10-01
+### Fixed
+- Fix test failing when giving arguments to the test binary.
+
 ## [1.5.0] - 2020-08-27
 ### Added
 - Add alt-e/s keys for expanding/shrinking the selected block

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmon"
-version = "1.5.0"
+version = "1.5.1"
 description = "Linux kernel manager and activity monitor"
 authors = ["orhun <orhunparmaksiz@gmail.com>"]
 license = "GPL-3.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -571,11 +571,12 @@ mod tests {
 	use crate::event::Events;
 	use crate::kernel::info;
 	use crate::kernel::lkm::ListArgs;
+	use clap::ArgMatches;
 	use tui::backend::TestBackend;
 	use tui::Terminal;
 	#[test]
 	fn test_app() {
-		let args = util::parse_args();
+		let args = ArgMatches::default();
 		let mut kernel_modules =
 			KernelModules::new(ListArgs::new(&args), Style::new(&args));
 		let mut app = App::new(Block::ModuleTable, kernel_modules.style.clone());

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -379,10 +379,9 @@ impl KernelModules<'_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use clap::App;
 	#[test]
 	fn test_kernel_modules() {
-		let args = App::new("test").get_matches();
+		let args = ArgMatches::default();
 		let mut list_args = ListArgs::new(&args);
 		list_args.sort = SortType::Size;
 		list_args.reverse = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,14 +522,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use clap::ArgMatches;
 	use std::sync::mpsc::Sender;
 	use std::thread;
 	use std::time::Duration;
 	use tui::backend::TestBackend;
 	#[test]
 	fn test_tui() -> Result<(), Box<dyn Error>> {
-		main()?;
-		let args = util::parse_args();
+		let args = ArgMatches::default();
 		let kernel = Kernel::new(&args);
 		let events = Events::new(100, &kernel.logs);
 		let tx = events.tx.clone();

--- a/src/style.rs
+++ b/src/style.rs
@@ -246,18 +246,11 @@ impl<'a> StyledText<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use clap::{App, Arg};
+	use clap::ArgMatches;
 	use tui::widgets::Text;
 	#[test]
 	fn test_style() {
-		let mut args = App::new("test").get_matches();
-		for color in vec!["black", "000000", "lightblue", "3c70a4"] {
-			args = App::new("test")
-				.arg(Arg::with_name("color").default_value(color))
-				.arg(Arg::with_name("accent-color").default_value(color))
-				.get_matches();
-			Style::new(&args);
-		}
+		let args = ArgMatches::default();
 		let style = Style::new(&args);
 		let mut styled_text = StyledText::default();
 		styled_text.set(

--- a/src/util.rs
+++ b/src/util.rs
@@ -156,12 +156,6 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 mod tests {
 	use super::*;
 	#[test]
-	fn test_parse_args() {
-		let matches = parse_args();
-		assert_ne!(0, matches.args.len());
-		assert_eq!(true, matches.usage.unwrap().lines().count() > 1);
-	}
-	#[test]
 	fn test_exec_cmd() {
 		assert_eq!("test", exec_cmd("printf", &["test"]).unwrap());
 		assert_eq!(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replaced use of `clap::App` and actual cli parsing of `std::env::args()` during tests with a stub (an empty arg matches `ArgMatches::default()`). For more details I found this explanation quite usefull https://github.com/clap-rs/clap/issues/1696#issuecomment-587064562.

I have some doubts about a few tests:
* `style::tests::test_style` I'm not sure what these first few lines were doing but the test passed without them so I guess they didn't impact the test?
* `tests::test_tui` removed call to `main()?`, same thing, test passed without so it didn't impact the test?
* `util::tests::test_parse_args` was removed, I don't think a can make it pass without actually parsing the cli.

Are these changes ok with you or do you want me to rework them in some way?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes test failure when arguments are given to the test binary generated by `cargo test`. For instance `cargo test -- --test-threads 8`. This is required by nixos where support for running the tests in parallel for rust packages was recently introduced. That's why kmon on the current stable release of nixos (20.03) is unaffected but breaks on the upcoming release (20.09).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `cargo test -- --test-threads 8` and the tests passed.

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
