### PR TITLE
Update kmon.8 to include string "kmod"

### DIFF
--- a/man/kmon.8
+++ b/man/kmon.8
@@ -7,7 +7,7 @@ kmon \- manage the kernel modules and monitor kernel activities
 .B kmon
 [FLAGS] [OPTIONS] [SUBCOMMANDS]
 .SH DESCRIPTION
-kmon provides a text-based user interface for managing the Linux kernel modules and monitoring the kernel activities. 
+kmon provides a text-based user interface for managing Linux kernel modules (kmod) and monitoring kernel activities. 
 .SH "USAGE:"
 Press '?' while running the terminal UI to see key bindings.
 .SS "FLAGS:"


### PR DESCRIPTION
## Description
Added string "(kmod)" to make finding the program easier via `apropos` /  `man -k`
Minor grammar cleanup - removed two unnecessary Definite Article's in description sentence.
## Motivation and Context
Closes https://github.com/orhun/kmon/issues/24
## How Has This Been Tested?
Tested on Arch linux
## Screenshots / Output (if appropriate):
N/A
## Types of changes
- [x] Documentation (no code change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.

This last section does not appear applicable to this PR.