### PR TITLE
chore: Switch to `ratatui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,8 +193,8 @@ dependencies = [
  "colorsys",
  "copypasta-ext",
  "enum-iterator",
- "termion",
- "tui",
+ "ratatui",
+ "termion 1.5.6",
  "unicode-width",
 ]
 
@@ -377,6 +377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "termion 2.0.1",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,16 +492,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.19.0"
+name = "termion"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
 dependencies = [
- "bitflags",
- "cassowary",
- "termion",
- "unicode-segmentation",
- "unicode-width",
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "Cargo.*", "LICENSE", "README.md", "CHANGELOG.md"]
 edition = "2021"
 
 [dependencies]
-tui = { version = "0.19.0", default-features = false, features = ["termion"] }
+tui = { package = "ratatui", version = "0.20.1", default-features = false, features = ["termion"] }
 termion = "1.5.6"
 bytesize = "1.1.0"
 unicode-width = "0.1.10"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Update Cargo.{toml,lock} according to the [instructions](https://github.com/tui-rs-revival/ratatui/#install) to use `ratatui` instead of `tui`.

## Motivation and Context

Resolves #39

## How Has This Been Tested?

No code changes besides the replacement of the `tui` dependency with a compatible one `ratatui` were made. Let’s see what CI has to say.

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) --> — dependency replacement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
