### PR TITLE
style(clippy): fix all new clippy errors with 'rustc:1.73.0'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,9 +457,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -572,7 +572,7 @@ impl App {
 			.items
 			.iter()
 			.map(|(_, text)| text.width())
-			.chain(vec![block_title.width()].into_iter())
+			.chain(vec![block_title.width()])
 			.max()
 			.map(|v| v as f32 + 7.)
 		{
@@ -731,32 +731,24 @@ mod tests {
 		let backend = TestBackend::new(20, 10);
 		let mut terminal = Terminal::new(backend).unwrap();
 		terminal
-			.draw(|mut f| {
+			.draw(|f| {
 				let size = f.size();
 				app.selected_block = Block::UserInput;
-				app.draw_user_input(
-					&mut f,
-					size,
-					&Events::new(100, &kernel_logs).tx,
-				);
-				app.draw_kernel_info(
-					&mut f,
-					size,
-					&info::KernelInfo::new().current_info,
-				);
+				app.draw_user_input(f, size, &Events::new(100, &kernel_logs).tx);
+				app.draw_kernel_info(f, size, &info::KernelInfo::new().current_info);
 				app.input_query = String::from("a");
-				app.draw_kernel_modules(&mut f, size, &mut kernel_modules);
-				app.draw_module_info(&mut f, size, &mut kernel_modules);
-				app.draw_kernel_activities(&mut f, size, &mut kernel_logs);
+				app.draw_kernel_modules(f, size, &mut kernel_modules);
+				app.draw_module_info(f, size, &mut kernel_modules);
+				app.draw_kernel_activities(f, size, &mut kernel_logs);
 			})
 			.unwrap();
 	}
 	#[test]
 	fn test_input_mode() {
 		let mut input_mode = InputMode::Load;
-		assert_eq!(false, input_mode.is_none());
-		assert_eq!(true, input_mode.to_string().contains("Load"));
+		assert!(!input_mode.is_none());
+		assert!(input_mode.to_string().contains("Load"));
 		input_mode = InputMode::None;
-		assert_eq!(true, input_mode.to_string().contains("Search"));
+		assert!(input_mode.to_string().contains("Search"));
 	}
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -89,11 +89,9 @@ mod tests {
 		loop {
 			let tx = events.tx.clone();
 			thread::spawn(move || {
-				match tx.send(Event::Input(Key::Char(
+				let _ = tx.send(Event::Input(Key::Char(
 					std::char::from_digit(i, 10).unwrap_or('x'),
-				))) {
-					_ => {}
-				};
+				)));
 			});
 			i += 1;
 			match events.rx.recv()? {
@@ -103,7 +101,7 @@ mod tests {
 					}
 				}
 				Event::Tick => thread::sleep(Duration::from_millis(100)),
-				Event::Kernel(log) => assert_ne!(true, log.is_empty()),
+				Event::Kernel(log) => assert!(!log.is_empty()),
 			}
 		}
 		Ok(())

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -158,7 +158,7 @@ mod tests {
 	#[test]
 	fn test_module_command() {
 		let module_command = ModuleCommand::None;
-		assert_eq!(true, module_command == ModuleCommand::None);
+		assert!(module_command == ModuleCommand::None);
 
 		assert_ne!("", ModuleCommand::None.get("test").title);
 		assert_ne!("", ModuleCommand::Load.get("module").desc);

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -420,15 +420,15 @@ mod tests {
 		kernel_modules
 			.set_current_command(ModuleCommand::Load, String::from("test"));
 		assert_eq!("test", kernel_modules.current_name);
-		assert_eq!(false, kernel_modules.execute_command());
+		assert!(!kernel_modules.execute_command());
 		kernel_modules.set_current_command(ModuleCommand::Load, String::new());
 		kernel_modules.scroll_list(ScrollDirection::Top);
-		for command in vec![
+		for command in [
 			ModuleCommand::Unload,
 			ModuleCommand::Blacklist,
 			ModuleCommand::None,
 		] {
-			kernel_modules.set_current_command(command.clone(), String::new());
+			kernel_modules.set_current_command(command, String::new());
 			assert_eq!(!command.is_none(), kernel_modules.cancel_execution());
 		}
 	}

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -1,5 +1,6 @@
 use crate::app::ScrollDirection;
 use crate::util;
+use std::fmt::Write as _;
 
 /* Kernel activity logs */
 #[derive(Clone, Debug, Default)]
@@ -24,12 +25,11 @@ impl KernelLogs {
 		)
 		.unwrap_or_else(|_| String::from("failed to retrieve dmesg output"));
 		let logs_updated =
-			self.output.lines().rev().next().unwrap_or_default() != self.last_line;
+			self.output.lines().next_back().unwrap_or_default() != self.last_line;
 		self.last_line = self
 			.output
 			.lines()
-			.rev()
-			.next()
+			.next_back()
 			.unwrap_or_default()
 			.to_string();
 		logs_updated
@@ -67,8 +67,10 @@ impl KernelLogs {
 					})
 					.unwrap_or(0),
 			)
-			.map(|i| format!("{i}\n"))
-			.collect::<String>();
+			.fold(String::new(), |mut s, i| {
+				let _ = writeln!(s, "{i}");
+				s
+			});
 		&self.selected_output
 	}
 
@@ -114,7 +116,7 @@ mod tests {
 		{
 			kernel_logs.scroll(*direction, *direction == ScrollDirection::Top);
 		}
-		assert_eq!(true, kernel_logs.update());
+		assert!(kernel_logs.update());
 		assert_ne!(0, kernel_logs.output.lines().count());
 		assert_ne!(0, kernel_logs.select(10, 2).len());
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,7 @@ mod tests {
 		let tx = events.tx.clone();
 		thread::spawn(move || {
 			/* Test the general keys. */
-			for key in vec![
+			for key in [
 				Key::Char('?'),
 				Key::Ctrl('t'),
 				Key::Ctrl('b'),
@@ -604,10 +604,10 @@ mod tests {
 			}
 			send_key(&tx, Key::Char('r'));
 			/* Test the switch keys. */
-			for arrow_key in vec![Key::Right, Key::Left] {
-				for selected_key in vec![arrow_key; Block::CARDINALITY] {
+			for arrow_key in [Key::Right, Key::Left] {
+				for selected_key in [arrow_key; Block::CARDINALITY] {
 					send_key(&tx, selected_key);
-					for key in vec![
+					for key in [
 						Key::Up,
 						Key::Down,
 						Key::Down,
@@ -621,7 +621,7 @@ mod tests {
 				}
 			}
 			/* Test the input mode keys. */
-			for key in vec![
+			for key in [
 				Key::Char('v'),
 				Key::Delete,
 				Key::Char('~'),

--- a/src/style.rs
+++ b/src/style.rs
@@ -254,7 +254,7 @@ mod tests {
 		let mut unicode = Unicode::new(true);
 		for symbol in unicode.symbols.clone() {
 			if symbol.0 != Symbol::Blank {
-				assert_eq!(true, symbol.1[1].len() < 2)
+				assert!(symbol.1[1].len() < 2)
 			}
 		}
 		unicode.replace = false;


### PR DESCRIPTION
## Description
Rust had a few new versions since the last CI job had run. Since `clippy` is launched with `--deny warnings` and new lints have been implemented since, there is few errors that any new CI job will trigger. This PR fixes all new errors due to `clippy:1.73.0`.

## Motivation and Context
Working on https://github.com/orhun/kmon/pull/110, the CI was failing for reasons unrelated to the PR.

## How Has This Been Tested?
No change of functionality, just running `clippy` should be enough (and the CI takes care of that).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other : only stylistic changes

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
