### PR TITLE
fix: Do not panic when /proc/modules does not exist

### DIFF
--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -114,8 +114,13 @@ impl KernelModules<'_> {
 			SortType::Dependent => module_read_cmd += " | sort -n -r -t ' ' -k3",
 			_ => {}
 		}
-		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])
-			.unwrap_or_else(|_| String::new());
+		let modules_content = match util::exec_cmd("sh", &["-c", &module_read_cmd]) {
+			Ok(v) => v,
+			Err(e) => {
+				eprintln!("{e}");
+				String::new()
+			}
+		};
 		/* Parse content for module name, size and related information. */
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -115,7 +115,7 @@ impl KernelModules<'_> {
 			_ => {}
 		}
 		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])
-			.expect("failed to read /proc/modules");
+			.unwrap_or_else(|_| String::new());
 		/* Parse content for module name, size and related information. */
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -34,6 +34,6 @@ impl Kernel {
 	pub fn refresh(&mut self) {
 		self.logs.refresh();
 		self.info.refresh();
-		self.modules.refresh();
+		let _ = self.modules.refresh();
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
+use std::io::{self, Write};
+use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -15,6 +17,31 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
+
+	let raw_output = io::stdout().into_raw_mode()?;
+	raw_output.suspend_raw_mode()?;
+
+	let panic_hook = panic::take_hook();
+
+	panic::set_hook(Box::new (move |panic| {
+		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+			let mut output = io::stdout();
+
+			write!(
+				output,
+				"{}{}{}",
+				termion::clear::All,
+				termion::screen::ToMainScreen,
+				termion::cursor::Show
+			)?;
+			raw_output.suspend_raw_mode()?;
+			output.flush()?;
+			Ok(())
+		};
+
+		panic_cleanup().expect("Failed to cleanup after panic");
+		panic_hook(panic);
+	}));
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
-use std::io::{self, Write};
-use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -17,31 +15,6 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
-
-	let raw_output = io::stdout().into_raw_mode()?;
-	raw_output.suspend_raw_mode()?;
-
-	let panic_hook = panic::take_hook();
-
-	panic::set_hook(Box::new (move |panic| {
-		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
-			let mut output = io::stdout();
-
-			write!(
-				output,
-				"{}{}{}",
-				termion::clear::All,
-				termion::screen::ToMainScreen,
-				termion::cursor::Show
-			)?;
-			raw_output.suspend_raw_mode()?;
-			output.flush()?;
-			Ok(())
-		};
-
-		panic_cleanup().expect("Failed to cleanup after panic");
-		panic_hook(panic);
-	}));
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(


### PR DESCRIPTION
## Description
As it mentioned in issue I linked below, chromebooks and few types of generic linux kernels does not include `/proc/modules` so program panics.

## Motivation and Context
fixes #138

I'll also implement parsing to return empty set of modules.

## How Has This Been Tested?
I couldn't test this bug fix, because I don't use chromebook or generic linux kernel, so I hope who created issue can test on his device. If there are any ways to reproduce that kernel types please let me know :)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
