### PR TITLE
Add a panic hook to reset terminal upon panic

### DIFF
--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -114,8 +114,13 @@ impl KernelModules<'_> {
 			SortType::Dependent => module_read_cmd += " | sort -n -r -t ' ' -k3",
 			_ => {}
 		}
-		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])
-			.unwrap_or_else(|_| String::new());
+		let modules_content = match util::exec_cmd("sh", &["-c", &module_read_cmd]) {
+			Ok(v) => v,
+			Err(e) => {
+				eprintln!("{e}");
+				String::new()
+			}
+		};
 		/* Parse content for module name, size and related information. */
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -115,7 +115,7 @@ impl KernelModules<'_> {
 			_ => {}
 		}
 		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])
-			.expect("failed to read /proc/modules");
+			.unwrap_or_else(|_| String::new());
 		/* Parse content for module name, size and related information. */
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
+use std::io::{self, Write};
+use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -15,6 +17,31 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
+
+	let raw_output = io::stdout().into_raw_mode()?;
+	raw_output.suspend_raw_mode()?;
+
+	let panic_hook = panic::take_hook();
+
+	panic::set_hook(Box::new (move |panic| {
+		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+			let mut output = io::stdout();
+
+			write!(
+				output,
+				"{}{}{}",
+				termion::clear::All,
+				termion::screen::ToMainScreen,
+				termion::cursor::Show
+			)?;
+			raw_output.suspend_raw_mode()?;
+			output.flush()?;
+			Ok(())
+		};
+
+		panic_cleanup().expect("Failed to cleanup after panic");
+		panic_hook(panic);
+	}));
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
+use std::io::{self, Write};
+use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -15,6 +17,32 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
+
+	let raw_output = io::stdout().into_raw_mode()?;
+	raw_output.suspend_raw_mode()?;
+
+	let panic_hook = panic::take_hook();
+
+	panic::set_hook(Box::new (move |panic| {
+		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+			let mut output = io::stdout();
+
+			write!(
+				output,
+				"{}{}{}",
+				termion::clear::All,
+				termion::screen::ToMainScreen,
+				termion::cursor::Show
+			)?;
+			raw_output.suspend_raw_mode()?;
+			output.flush()?;
+			Ok(())
+		};
+
+		panic_cleanup().expect("Failed to cleanup after panic");
+		panic_hook(panic);
+	}));
+
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
-use std::io::{self, Write};
-use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -17,31 +15,6 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
-
-	let raw_output = io::stdout().into_raw_mode()?;
-	raw_output.suspend_raw_mode()?;
-
-	let panic_hook = panic::take_hook();
-
-	panic::set_hook(Box::new (move |panic| {
-		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
-			let mut output = io::stdout();
-
-			write!(
-				output,
-				"{}{}{}",
-				termion::clear::All,
-				termion::screen::ToMainScreen,
-				termion::cursor::Show
-			)?;
-			raw_output.suspend_raw_mode()?;
-			output.flush()?;
-			Ok(())
-		};
-
-		panic_cleanup().expect("Failed to cleanup after panic");
-		panic_hook(panic);
-	}));
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(


### PR DESCRIPTION
## Description
I implemented termion panic handler for the kmon. Mainly based on the script that's mentioned in the issue I linked below:

https://github.com/ratatui-org/ratatui/issues/1005

## Motivation and Context
https://github.com/orhun/kmon/issues/83

## How Has This Been Tested?
I put panic!() to the `lib.rs` to generate panic and test if terminal will be messed up or not. 

## Screenshots / Output (if appropriate):
![Screenshot from 2024-04-02 20-31-26](https://github.com/orhun/kmon/assets/46849939/020e5c63-30c2-4800-9263-22d6faaf15ea)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
