### PR TITLE
feat: Add a panic hook to reset terminal upon panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use kmon::args;
-use kmon::util;
 use kmon::event::Events;
 use kmon::kernel::Kernel;
+use kmon::util;
 use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
+use std::io::{self, Write};
+use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -15,6 +17,32 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
+
+	let raw_output = io::stdout().into_raw_mode()?;
+	raw_output.suspend_raw_mode()?;
+
+	let panic_hook = panic::take_hook();
+
+	panic::set_hook(Box::new (move |panic| {
+		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+			let mut output = io::stdout();
+
+			write!(
+				output,
+				"{}{}{}",
+				termion::clear::All,
+				termion::screen::ToMainScreen,
+				termion::cursor::Show
+			)?;
+			raw_output.suspend_raw_mode()?;
+			output.flush()?;
+			Ok(())
+		};
+
+		panic_cleanup().expect("Failed to cleanup after panic");
+		panic_hook(panic);
+	}));
+
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
 use kmon::args;
+use kmon::util;
 use kmon::event::Events;
 use kmon::kernel::Kernel;
 use ratatui::backend::TermionBackend;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io::stdout;
-use std::io::{self, Write};
-use std::panic;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
@@ -17,32 +16,6 @@ use termion::screen::IntoAlternateScreen;
  * @return Result
  */
 fn main() -> Result<(), Box<dyn Error>> {
-
-	let raw_output = io::stdout().into_raw_mode()?;
-	raw_output.suspend_raw_mode()?;
-
-	let panic_hook = panic::take_hook();
-
-	panic::set_hook(Box::new (move |panic| {
-		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
-			let mut output = io::stdout();
-
-			write!(
-				output,
-				"{}{}{}",
-				termion::clear::All,
-				termion::screen::ToMainScreen,
-				termion::cursor::Show
-			)?;
-			raw_output.suspend_raw_mode()?;
-			output.flush()?;
-			Ok(())
-		};
-
-		panic_cleanup().expect("Failed to cleanup after panic");
-		panic_hook(panic);
-	}));
-
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);
 	let events = Events::new(
@@ -53,6 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 		&kernel.logs,
 	);
 	if !cfg!(test) {
+		util::setup_panic_hook()?;
 		let stdout = stdout().into_raw_mode()?.into_alternate_screen()?;
 		let stdout = MouseTerminal::from(stdout);
 		let backend = TermionBackend::new(stdout);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
-use std::process::Command;
 use std::error::Error;
 use std::io::{self, Write};
 use std::panic;
+use std::process::Command;
 use termion::raw::IntoRawMode;
 
 /* Macro for concise initialization of hashmap */
@@ -66,31 +66,37 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 	}
 }
 
+/**
+ * Sets up the panic hook for the terminal.
+ *
+ * See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
+ *
+ * @return Result
+ */
 pub fn setup_panic_hook() -> Result<(), Box<dyn Error>> {
-    let raw_output = io::stdout().into_raw_mode()?;
+	let raw_output = io::stdout().into_raw_mode()?;
+	raw_output.suspend_raw_mode()?;
 
-    raw_output.suspend_raw_mode()?;
+	let panic_hook = panic::take_hook();
+	panic::set_hook(Box::new(move |panic| {
+		let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+			let mut output = io::stdout();
+			write!(
+				output,
+				"{}{}{}",
+				termion::clear::All,
+				termion::screen::ToMainScreen,
+				termion::cursor::Show
+			)?;
+			raw_output.suspend_raw_mode()?;
+			output.flush()?;
+			Ok(())
+		};
+		panic_cleanup().expect("failed to clean up for panic");
+		panic_hook(panic);
+	}));
 
-    let panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |panic| {
-        let panic_cleanup = || -> Result<(), Box<dyn Error>> {
-            let mut output = io::stdout();
-            write!(
-                output,
-                "{}{}{}",
-                termion::clear::All,
-                termion::screen::ToMainScreen,
-                termion::cursor::Show
-            )?;
-            raw_output.suspend_raw_mode()?;
-            output.flush()?;
-            Ok(())
-        };
-        panic_cleanup().expect("failed to clean up for panic");
-        panic_hook(panic);
-    }));
-
-    Ok(())
+	Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
I implemented termion panic handler for the kmon. Mainly based on the script that's mentioned in the issue I linked below:

https://github.com/ratatui-org/ratatui/issues/1005

## Motivation and Context
https://github.com/orhun/kmon/issues/83

## How Has This Been Tested?
I put panic!() to the lib.rs to generate panic and test if terminal will be messed up or not.

## Screenshots / Output (if appropriate):
![Screenshot from 2024-04-02 20-31-08](https://github.com/orhun/kmon/assets/46849939/23f602b7-2085-4fe1-8816-c9bd55cd9dd0)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
