### PR TITLE
doc: Use the conventional comment syntax

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,7 +51,6 @@ impl ScrollDirection {
 	
 	/// Return iterator of the available scroll directions.
 	 
-	/// @return Iter
 	 
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, ScrollDirection> {
@@ -107,7 +106,6 @@ impl InputMode {
 	
 	/// Check if input mode is set.
 	 
-	/// @return bool
 	
 	pub fn is_none(self) -> bool {
 		self == Self::None
@@ -146,9 +144,6 @@ impl App {
 	
 	/// Create a new app instance.
 	 
-	/// @param  Block
-	/// @param  Style
-	/// @return App
 	
 	pub fn new(block: Block, style: Style) -> Self {
 		Self {
@@ -192,8 +187,6 @@ impl App {
 	
 	/// Get style depending on the selected state of the block.
 	 
-	/// @param  block
-	/// @return TuiStyle
 	
 	pub fn block_style(&self, block: Block) -> TuiStyle {
 		if self.show_options {
@@ -208,7 +201,7 @@ impl App {
 	
 	/// Get the size of the selected block.
 	 
-	/// @return u16
+
 	
 	pub fn block_size(&mut self) -> &mut u16 {
 		match self.selected_block {
@@ -221,8 +214,7 @@ impl App {
 	
 	/// Get clipboard contents as String.
 	 
-	/// @return contents
-	
+
 	pub fn get_clipboard_contents(&mut self) -> String {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Ok(contents) = clipboard.get_contents() {
@@ -235,8 +227,7 @@ impl App {
 	
 	/// Set clipboard contents.
 	
-	/// @param contents
-	
+
 	pub fn set_clipboard_contents(&mut self, contents: &str) {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Err(e) = clipboard.set_contents(contents.to_string()) {
@@ -248,7 +239,6 @@ impl App {
 	
 	/// Show help message on the information block.
 	 
-	/// @param kernel_modules
 	
 	pub fn show_help_message(&mut self, kernel_modules: &mut KernelModules<'_>) {
 		let key_bindings: Vec<(&str, &str)> = util::KEY_BINDINGS.to_vec();
@@ -278,7 +268,6 @@ impl App {
 	
 	/// Show dependent modules on the information block.
 	
-	/// @param kernel_modules
 	
 	#[allow(clippy::nonminimal_bool)]
 	pub fn show_dependent_modules(
@@ -320,9 +309,7 @@ impl App {
 	
 	/// Draw a block according to the index.
 	
-	/// @param frame
-	/// @param area
-	/// @param kernel
+
 	
 	pub fn draw_dynamic_block(
 		&mut self,
@@ -345,9 +332,7 @@ impl App {
 	
 	/// Draw a paragraph widget for using as user input.
 	
-	/// @param frame
-	/// @param area
-	/// @param tx
+
 	
 	pub fn draw_user_input(
 		&self,
@@ -390,9 +375,7 @@ impl App {
 	
 	/// Draw a paragraph widget for showing the kernel information.
 	 
-	/// @param frame
-	/// @param area
-	/// @param info
+
 	 
 	pub fn draw_kernel_info(&self, frame: &mut Frame, area: Rect, info: &[String]) {
 		frame.render_widget(
@@ -420,9 +403,7 @@ impl App {
 	
 	/// Configure and draw kernel modules table.
 	 
-	/// @param frame
-	/// @param area
-	/// @param kernel_modules
+
 	
 	pub fn draw_kernel_modules(
 		&mut self,
@@ -523,8 +504,7 @@ impl App {
 	
 	/// Draws the options menu as a popup.
 	 
-	/// @param frame
-	/// @param area
+
 	
 	pub fn draw_options_menu(
 		&mut self,
@@ -606,9 +586,6 @@ impl App {
 	
 	/// Draw a paragraph widget for showing module information.
 	 
-	/// @param frame
-	/// @param area
-	/// @param kernel_modules
 	
 	pub fn draw_module_info(
 		&self,
@@ -654,9 +631,6 @@ impl App {
 	
 	/// Draw a paragraph widget for showing kernel activities.
 	
-	/// @param frame
-	/// @param area
-	/// @param kernel_logs
 	
 	pub fn draw_kernel_activities(
 		&self,

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,10 +22,10 @@ use std::sync::mpsc::Sender;
 use termion::event::Key;
 use unicode_width::UnicodeWidthStr;
 
-/* Table header of the module table */
+/// Table header of the module table 
 pub const TABLE_HEADER: &[&str] = &[" Module", "Size", "Used by"];
 
-/* Available options in the module management menu */
+/// Available options in the module management menu 
 const OPTIONS: &[(&str, &str)] = &[
 	("unload", "Unload the module"),
 	("reload", "Reload the module"),
@@ -36,7 +36,7 @@ const OPTIONS: &[(&str, &str)] = &[
 	("clear", "Clear the ring buffer"),
 ];
 
-/* Supported directions of scrolling */
+/// Supported directions of scrolling 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScrollDirection {
 	Up,
@@ -48,11 +48,11 @@ pub enum ScrollDirection {
 }
 
 impl ScrollDirection {
-	/**
-	 * Return iterator of the available scroll directions.
-	 *
-	 * @return Iter
-	 */
+	
+	/// Return iterator of the available scroll directions.
+	 
+	/// @return Iter
+	 
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, ScrollDirection> {
 		[
@@ -67,7 +67,7 @@ impl ScrollDirection {
 	}
 }
 
-/* Main blocks of the terminal */
+/// Main blocks of the terminal 
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Sequence)]
 pub enum Block {
@@ -77,14 +77,14 @@ pub enum Block {
 	Activities,
 }
 
-/* Sizes of the terminal blocks */
+/// Sizes of the terminal blocks 
 pub struct BlockSize {
 	pub input: u16,
 	pub info: u16,
 	pub activities: u16,
 }
 
-/* Default initialization values for BlockSize */
+/// Default initialization values for BlockSize 
 impl Default for BlockSize {
 	fn default() -> Self {
 		Self {
@@ -95,7 +95,7 @@ impl Default for BlockSize {
 	}
 }
 
-/* User input mode */
+/// User input mode 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Sequence)]
 pub enum InputMode {
 	None,
@@ -104,17 +104,17 @@ pub enum InputMode {
 }
 
 impl InputMode {
-	/**
-	 * Check if input mode is set.
-	 *
-	 * @return bool
-	 */
+	
+	/// Check if input mode is set.
+	 
+	/// @return bool
+	
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
 }
 
-/* Implementation of Display for using InputMode members as string */
+/// Implementation of Display for using InputMode members as string 
 impl Display for InputMode {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		let mut input_mode = *self;
@@ -128,7 +128,7 @@ impl Display for InputMode {
 	}
 }
 
-/* Application settings and related methods  */
+/// Application settings and related methods  
 pub struct App {
 	pub selected_block: Block,
 	pub default_block: Block,
@@ -143,13 +143,13 @@ pub struct App {
 }
 
 impl App {
-	/**
-	 * Create a new app instance.
-	 *
-	 * @param  Block
-	 * @param  Style
-	 * @return App
-	 */
+	
+	/// Create a new app instance.
+	 
+	/// @param  Block
+	/// @param  Style
+	/// @return App
+	
 	pub fn new(block: Block, style: Style) -> Self {
 		Self {
 			selected_block: block,
@@ -178,7 +178,7 @@ impl App {
 		}
 	}
 
-	/* Reset app properties to default. */
+	/// Reset app properties to default. 
 	pub fn refresh(&mut self) {
 		self.selected_block = self.default_block;
 		self.block_size = BlockSize::default();
@@ -189,12 +189,12 @@ impl App {
 		self.show_options = false;
 	}
 
-	/**
-	 * Get style depending on the selected state of the block.
-	 *
-	 * @param  block
-	 * @return TuiStyle
-	 */
+	
+	/// Get style depending on the selected state of the block.
+	 
+	/// @param  block
+	/// @return TuiStyle
+	
 	pub fn block_style(&self, block: Block) -> TuiStyle {
 		if self.show_options {
 			self.style.colored
@@ -205,11 +205,11 @@ impl App {
 		}
 	}
 
-	/**
-	 * Get the size of the selected block.
-	 *
-	 * @return u16
-	 */
+	
+	/// Get the size of the selected block.
+	 
+	/// @return u16
+	
 	pub fn block_size(&mut self) -> &mut u16 {
 		match self.selected_block {
 			Block::ModuleInfo => &mut self.block_size.info,
@@ -218,11 +218,11 @@ impl App {
 		}
 	}
 
-	/**
-	 * Get clipboard contents as String.
-	 *
-	 * @return contents
-	 */
+	
+	/// Get clipboard contents as String.
+	 
+	/// @return contents
+	
 	pub fn get_clipboard_contents(&mut self) -> String {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Ok(contents) = clipboard.get_contents() {
@@ -232,11 +232,11 @@ impl App {
 		String::new()
 	}
 
-	/**
-	 * Set clipboard contents.
-	 *
-	 * @param contents
-	 */
+	
+	/// Set clipboard contents.
+	
+	/// @param contents
+	
 	pub fn set_clipboard_contents(&mut self, contents: &str) {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Err(e) = clipboard.set_contents(contents.to_string()) {
@@ -245,11 +245,11 @@ impl App {
 		}
 	}
 
-	/**
-	 * Show help message on the information block.
-	 *
-	 * @param kernel_modules
-	 */
+	
+	/// Show help message on the information block.
+	 
+	/// @param kernel_modules
+	
 	pub fn show_help_message(&mut self, kernel_modules: &mut KernelModules<'_>) {
 		let key_bindings: Vec<(&str, &str)> = util::KEY_BINDINGS.to_vec();
 		let mut help_text = Vec::new();
@@ -275,11 +275,11 @@ impl App {
 			.set(Text::from(help_text), help_text_raw.join("\n"));
 	}
 
-	/**
-	 * Show dependent modules on the information block.
-	 *
-	 * @param kernel_modules
-	 */
+	
+	/// Show dependent modules on the information block.
+	
+	/// @param kernel_modules
+	
 	#[allow(clippy::nonminimal_bool)]
 	pub fn show_dependent_modules(
 		&mut self,
@@ -317,13 +317,13 @@ impl App {
 		}
 	}
 
-	/**
-	 * Draw a block according to the index.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param kernel
-	 */
+	
+	/// Draw a block according to the index.
+	
+	/// @param frame
+	/// @param area
+	/// @param kernel
+	
 	pub fn draw_dynamic_block(
 		&mut self,
 		frame: &mut Frame,
@@ -342,13 +342,13 @@ impl App {
 		}
 	}
 
-	/**
-	 * Draw a paragraph widget for using as user input.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param tx
-	 */
+	
+	/// Draw a paragraph widget for using as user input.
+	
+	/// @param frame
+	/// @param area
+	/// @param tx
+	
 	pub fn draw_user_input(
 		&self,
 		frame: &mut Frame,
@@ -387,13 +387,13 @@ impl App {
 		);
 	}
 
-	/**
-	 * Draw a paragraph widget for showing the kernel information.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param info
-	 */
+	
+	/// Draw a paragraph widget for showing the kernel information.
+	 
+	/// @param frame
+	/// @param area
+	/// @param info
+	 
 	pub fn draw_kernel_info(&self, frame: &mut Frame, area: Rect, info: &[String]) {
 		frame.render_widget(
 			Paragraph::new(Span::raw(&info[1]))
@@ -417,20 +417,20 @@ impl App {
 		);
 	}
 
-	/**
-	 * Configure and draw kernel modules table.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param kernel_modules
-	 */
+	
+	/// Configure and draw kernel modules table.
+	 
+	/// @param frame
+	/// @param area
+	/// @param kernel_modules
+	
 	pub fn draw_kernel_modules(
 		&mut self,
 		frame: &mut Frame,
 		area: Rect,
 		kernel_modules: &mut KernelModules<'_>,
 	) {
-		/* Filter the module list depending on the input query. */
+		/// Filter the module list depending on the input query. 
 		let mut kernel_module_list = kernel_modules.default_list.clone();
 		if (self.input_mode == InputMode::None
 			|| self.input_mode == InputMode::Search)
@@ -442,7 +442,7 @@ impl App {
 					.contains(&self.input_query.to_lowercase())
 			});
 		}
-		/* Append '...' if dependent modules exceed the block width. */
+		/// Append '...' if dependent modules exceed the block width. 
 		let dependent_width = (area.width / 2).saturating_sub(7) as usize;
 		for module in &mut kernel_module_list {
 			if module[2].len() > dependent_width {
@@ -451,13 +451,13 @@ impl App {
 			}
 		}
 		kernel_modules.list = kernel_module_list;
-		/* Set the scroll offset for modules. */
+		/// Set the scroll offset for modules. 
 		let modules_scroll_offset = area
 			.height
 			.checked_sub(5)
 			.and_then(|height| kernel_modules.index.checked_sub(height as usize))
 			.unwrap_or(0);
-		/* Set selected state of the modules and render the table widget. */
+		/// Set selected state of the modules and render the table widget. 
 		frame.render_widget(
 			Table::new(
 				kernel_modules
@@ -520,12 +520,12 @@ impl App {
 		}
 	}
 
-	/**
-	 * Draws the options menu as a popup.
-	 *
-	 * @param frame
-	 * @param area
-	 */
+	
+	/// Draws the options menu as a popup.
+	 
+	/// @param frame
+	/// @param area
+	
 	pub fn draw_options_menu(
 		&mut self,
 		frame: &mut Frame,
@@ -603,13 +603,13 @@ impl App {
 		);
 	}
 
-	/**
-	 * Draw a paragraph widget for showing module information.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param kernel_modules
-	 */
+	
+	/// Draw a paragraph widget for showing module information.
+	 
+	/// @param frame
+	/// @param area
+	/// @param kernel_modules
+	
 	pub fn draw_module_info(
 		&self,
 		frame: &mut Frame,
@@ -651,13 +651,13 @@ impl App {
 		);
 	}
 
-	/**
-	 * Draw a paragraph widget for showing kernel activities.
-	 *
-	 * @param frame
-	 * @param area
-	 * @param kernel_logs
-	 */
+	
+	/// Draw a paragraph widget for showing kernel activities.
+	
+	/// @param frame
+	/// @param area
+	/// @param kernel_logs
+	
 	pub fn draw_kernel_activities(
 		&self,
 		frame: &mut Frame,

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,10 +22,10 @@ use std::sync::mpsc::Sender;
 use termion::event::Key;
 use unicode_width::UnicodeWidthStr;
 
-/// Table header of the module table 
+/// Table header of the module table
 pub const TABLE_HEADER: &[&str] = &[" Module", "Size", "Used by"];
 
-/// Available options in the module management menu 
+/// Available options in the module management menu
 const OPTIONS: &[(&str, &str)] = &[
 	("unload", "Unload the module"),
 	("reload", "Reload the module"),
@@ -36,7 +36,7 @@ const OPTIONS: &[(&str, &str)] = &[
 	("clear", "Clear the ring buffer"),
 ];
 
-/// Supported directions of scrolling 
+/// Supported directions of scrolling
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScrollDirection {
 	Up,
@@ -48,7 +48,6 @@ pub enum ScrollDirection {
 }
 
 impl ScrollDirection {
-	
 	/// Return iterator of the available scroll directions.
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, ScrollDirection> {
@@ -64,7 +63,7 @@ impl ScrollDirection {
 	}
 }
 
-/// Main blocks of the terminal 
+/// Main blocks of the terminal
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Sequence)]
 pub enum Block {
 	UserInput,
@@ -73,14 +72,14 @@ pub enum Block {
 	Activities,
 }
 
-/// Sizes of the terminal blocks 
+/// Sizes of the terminal blocks
 pub struct BlockSize {
 	pub input: u16,
 	pub info: u16,
 	pub activities: u16,
 }
 
-/// Default initialization values for BlockSize 
+/// Default initialization values for BlockSize
 impl Default for BlockSize {
 	fn default() -> Self {
 		Self {
@@ -91,7 +90,7 @@ impl Default for BlockSize {
 	}
 }
 
-/// User input mode 
+/// User input mode
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Sequence)]
 pub enum InputMode {
 	None,
@@ -100,14 +99,13 @@ pub enum InputMode {
 }
 
 impl InputMode {
-	
 	/// Check if input mode is set.
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
 }
 
-/// Implementation of Display for using InputMode members as string 
+/// Implementation of Display for using InputMode members as string
 impl Display for InputMode {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		let mut input_mode = *self;
@@ -136,7 +134,6 @@ pub struct App {
 }
 
 impl App {
-	
 	/// Create a new app instance.
 	pub fn new(block: Block, style: Style) -> Self {
 		Self {
@@ -166,7 +163,7 @@ impl App {
 		}
 	}
 
-	/// Reset app properties to default. 
+	/// Reset app properties to default.
 	pub fn refresh(&mut self) {
 		self.selected_block = self.default_block;
 		self.block_size = BlockSize::default();
@@ -177,7 +174,6 @@ impl App {
 		self.show_options = false;
 	}
 
-	
 	/// Get style depending on the selected state of the block.
 	pub fn block_style(&self, block: Block) -> TuiStyle {
 		if self.show_options {
@@ -189,7 +185,6 @@ impl App {
 		}
 	}
 
-	
 	/// Get the size of the selected block.
 	pub fn block_size(&mut self) -> &mut u16 {
 		match self.selected_block {
@@ -199,7 +194,6 @@ impl App {
 		}
 	}
 
-	
 	/// Get clipboard contents as String.
 	pub fn get_clipboard_contents(&mut self) -> String {
 		if let Some(clipboard) = self.clipboard.as_mut() {
@@ -210,7 +204,6 @@ impl App {
 		String::new()
 	}
 
-	
 	/// Set clipboard contents.
 	pub fn set_clipboard_contents(&mut self, contents: &str) {
 		if let Some(clipboard) = self.clipboard.as_mut() {
@@ -220,7 +213,6 @@ impl App {
 		}
 	}
 
-	
 	/// Show help message on the information block.
 	pub fn show_help_message(&mut self, kernel_modules: &mut KernelModules<'_>) {
 		let key_bindings: Vec<(&str, &str)> = util::KEY_BINDINGS.to_vec();
@@ -247,7 +239,6 @@ impl App {
 			.set(Text::from(help_text), help_text_raw.join("\n"));
 	}
 
-	
 	/// Show dependent modules on the information block.
 	#[allow(clippy::nonminimal_bool)]
 	pub fn show_dependent_modules(
@@ -286,7 +277,6 @@ impl App {
 		}
 	}
 
-	
 	/// Draw a block according to the index.
 	pub fn draw_dynamic_block(
 		&mut self,
@@ -306,7 +296,6 @@ impl App {
 		}
 	}
 
-	
 	/// Draw a paragraph widget for using as user input.
 	pub fn draw_user_input(
 		&self,
@@ -346,7 +335,6 @@ impl App {
 		);
 	}
 
-	
 	/// Draw a paragraph widget for showing the kernel information.
 	pub fn draw_kernel_info(&self, frame: &mut Frame, area: Rect, info: &[String]) {
 		frame.render_widget(
@@ -371,7 +359,6 @@ impl App {
 		);
 	}
 
-	
 	/// Configure and draw kernel modules table.
 	pub fn draw_kernel_modules(
 		&mut self,
@@ -379,7 +366,7 @@ impl App {
 		area: Rect,
 		kernel_modules: &mut KernelModules<'_>,
 	) {
-		// Filter the module list depending on the input query. 
+		// Filter the module list depending on the input query.
 		let mut kernel_module_list = kernel_modules.default_list.clone();
 		if (self.input_mode == InputMode::None
 			|| self.input_mode == InputMode::Search)
@@ -391,7 +378,7 @@ impl App {
 					.contains(&self.input_query.to_lowercase())
 			});
 		}
-		// Append '...' if dependent modules exceed the block width. 
+		// Append '...' if dependent modules exceed the block width.
 		let dependent_width = (area.width / 2).saturating_sub(7) as usize;
 		for module in &mut kernel_module_list {
 			if module[2].len() > dependent_width {
@@ -400,13 +387,13 @@ impl App {
 			}
 		}
 		kernel_modules.list = kernel_module_list;
-		// Set the scroll offset for modules. 
+		// Set the scroll offset for modules.
 		let modules_scroll_offset = area
 			.height
 			.checked_sub(5)
 			.and_then(|height| kernel_modules.index.checked_sub(height as usize))
 			.unwrap_or(0);
-		// Set selected state of the modules and render the table widget. 
+		// Set selected state of the modules and render the table widget.
 		frame.render_widget(
 			Table::new(
 				kernel_modules
@@ -453,7 +440,8 @@ impl App {
 							self.style.unicode.get(Symbol::LeftBracket),
 							if !kernel_modules.list.is_empty() {
 								((kernel_modules.index + 1) as f64
-									/ kernel_modules.list.len() as f64 * 100.0) as u64
+									/ kernel_modules.list.len() as f64
+									* 100.0) as u64
 							} else {
 								0
 							},
@@ -469,7 +457,6 @@ impl App {
 		}
 	}
 
-	
 	/// Draws the options menu as a popup.
 	pub fn draw_options_menu(
 		&mut self,
@@ -548,7 +535,6 @@ impl App {
 		);
 	}
 
-	
 	/// Draw a paragraph widget for showing module information.
 	pub fn draw_module_info(
 		&self,
@@ -591,7 +577,6 @@ impl App {
 		);
 	}
 
-	
 	/// Draw a paragraph widget for showing kernel activities.
 	pub fn draw_kernel_activities(
 		&self,

--- a/src/app.rs
+++ b/src/app.rs
@@ -379,7 +379,7 @@ impl App {
 		area: Rect,
 		kernel_modules: &mut KernelModules<'_>,
 	) {
-		/// Filter the module list depending on the input query. 
+		// Filter the module list depending on the input query. 
 		let mut kernel_module_list = kernel_modules.default_list.clone();
 		if (self.input_mode == InputMode::None
 			|| self.input_mode == InputMode::Search)
@@ -391,7 +391,7 @@ impl App {
 					.contains(&self.input_query.to_lowercase())
 			});
 		}
-		/// Append '...' if dependent modules exceed the block width. 
+		// Append '...' if dependent modules exceed the block width. 
 		let dependent_width = (area.width / 2).saturating_sub(7) as usize;
 		for module in &mut kernel_module_list {
 			if module[2].len() > dependent_width {
@@ -400,13 +400,13 @@ impl App {
 			}
 		}
 		kernel_modules.list = kernel_module_list;
-		/// Set the scroll offset for modules. 
+		// Set the scroll offset for modules. 
 		let modules_scroll_offset = area
 			.height
 			.checked_sub(5)
 			.and_then(|height| kernel_modules.index.checked_sub(height as usize))
 			.unwrap_or(0);
-		/// Set selected state of the modules and render the table widget. 
+		// Set selected state of the modules and render the table widget. 
 		frame.render_widget(
 			Table::new(
 				kernel_modules

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,8 +50,6 @@ pub enum ScrollDirection {
 impl ScrollDirection {
 	
 	/// Return iterator of the available scroll directions.
-	 
-	 
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, ScrollDirection> {
 		[
@@ -67,7 +65,6 @@ impl ScrollDirection {
 }
 
 /// Main blocks of the terminal 
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Sequence)]
 pub enum Block {
 	UserInput,
@@ -105,8 +102,6 @@ pub enum InputMode {
 impl InputMode {
 	
 	/// Check if input mode is set.
-	 
-	
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
@@ -143,8 +138,6 @@ pub struct App {
 impl App {
 	
 	/// Create a new app instance.
-	 
-	
 	pub fn new(block: Block, style: Style) -> Self {
 		Self {
 			selected_block: block,
@@ -186,8 +179,6 @@ impl App {
 
 	
 	/// Get style depending on the selected state of the block.
-	 
-	
 	pub fn block_style(&self, block: Block) -> TuiStyle {
 		if self.show_options {
 			self.style.colored
@@ -200,9 +191,6 @@ impl App {
 
 	
 	/// Get the size of the selected block.
-	 
-
-	
 	pub fn block_size(&mut self) -> &mut u16 {
 		match self.selected_block {
 			Block::ModuleInfo => &mut self.block_size.info,
@@ -213,8 +201,6 @@ impl App {
 
 	
 	/// Get clipboard contents as String.
-	 
-
 	pub fn get_clipboard_contents(&mut self) -> String {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Ok(contents) = clipboard.get_contents() {
@@ -226,8 +212,6 @@ impl App {
 
 	
 	/// Set clipboard contents.
-	
-
 	pub fn set_clipboard_contents(&mut self, contents: &str) {
 		if let Some(clipboard) = self.clipboard.as_mut() {
 			if let Err(e) = clipboard.set_contents(contents.to_string()) {
@@ -238,8 +222,6 @@ impl App {
 
 	
 	/// Show help message on the information block.
-	 
-	
 	pub fn show_help_message(&mut self, kernel_modules: &mut KernelModules<'_>) {
 		let key_bindings: Vec<(&str, &str)> = util::KEY_BINDINGS.to_vec();
 		let mut help_text = Vec::new();
@@ -267,8 +249,6 @@ impl App {
 
 	
 	/// Show dependent modules on the information block.
-	
-	
 	#[allow(clippy::nonminimal_bool)]
 	pub fn show_dependent_modules(
 		&mut self,
@@ -308,9 +288,6 @@ impl App {
 
 	
 	/// Draw a block according to the index.
-	
-
-	
 	pub fn draw_dynamic_block(
 		&mut self,
 		frame: &mut Frame,
@@ -331,9 +308,6 @@ impl App {
 
 	
 	/// Draw a paragraph widget for using as user input.
-	
-
-	
 	pub fn draw_user_input(
 		&self,
 		frame: &mut Frame,
@@ -374,9 +348,6 @@ impl App {
 
 	
 	/// Draw a paragraph widget for showing the kernel information.
-	 
-
-	 
 	pub fn draw_kernel_info(&self, frame: &mut Frame, area: Rect, info: &[String]) {
 		frame.render_widget(
 			Paragraph::new(Span::raw(&info[1]))
@@ -402,9 +373,6 @@ impl App {
 
 	
 	/// Configure and draw kernel modules table.
-	 
-
-	
 	pub fn draw_kernel_modules(
 		&mut self,
 		frame: &mut Frame,
@@ -503,9 +471,6 @@ impl App {
 
 	
 	/// Draws the options menu as a popup.
-	 
-
-	
 	pub fn draw_options_menu(
 		&mut self,
 		frame: &mut Frame,
@@ -585,8 +550,6 @@ impl App {
 
 	
 	/// Draw a paragraph widget for showing module information.
-	 
-	
 	pub fn draw_module_info(
 		&self,
 		frame: &mut Frame,
@@ -630,8 +593,6 @@ impl App {
 
 	
 	/// Draw a paragraph widget for showing kernel activities.
-	
-	
 	pub fn draw_kernel_activities(
 		&self,
 		frame: &mut Frame,

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,7 +13,6 @@ const ASCII_LOGO: &str = "
 
 /// Parse command line arguments using clap.
  
-/// @return App
 
 pub fn get_args() -> App {
 	App::new(env!("CARGO_PKG_NAME"))

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, ArgAction, Command as App};
 
-/* ASCII format of the project logo */
+/// ASCII format of the project logo 
 const ASCII_LOGO: &str = "
  ``    ````````````    ````   ```````````    ```````````
 :NNs `hNNNNNNNNNNNNh` sNNNy   yNNNNNNNNNN+   dNNNNNNNNNN:
@@ -10,11 +10,11 @@ const ASCII_LOGO: &str = "
 :mmm/   dmmh   +mmm-  `mmmmmmmmmmmmmmmmmmmmmmmmmd   /mmm:
  ```    ```     ```    ``````````````````````````    ```";
 
-/**
- * Parse command line arguments using clap.
- *
- * @return App
- */
+
+/// Parse command line arguments using clap.
+ 
+/// @return App
+
 pub fn get_args() -> App {
 	App::new(env!("CARGO_PKG_NAME"))
 		.version(env!("CARGO_PKG_VERSION"))

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, ArgAction, Command as App};
 
-/// ASCII format of the project logo 
+/// ASCII format of the project logo
 const ASCII_LOGO: &str = "
  ``    ````````````    ````   ```````````    ```````````
 :NNs `hNNNNNNNNNNNNh` sNNNy   yNNNNNNNNNN+   dNNNNNNNNNN:
@@ -9,7 +9,6 @@ const ASCII_LOGO: &str = "
 /MMMs:::hhhs   oMMM+:::MMMNhhhNMMMdhhdMMMmhhhNMMN   /MMM/
 :mmm/   dmmh   +mmm-  `mmmmmmmmmmmmmmmmmmmmmmmmmd   /mmm:
  ```    ```     ```    ``````````````````````````    ```";
-
 
 /// Parse command line arguments using clap.
 pub fn get_args() -> App {

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,8 +12,6 @@ const ASCII_LOGO: &str = "
 
 
 /// Parse command line arguments using clap.
- 
-
 pub fn get_args() -> App {
 	App::new(env!("CARGO_PKG_NAME"))
 		.version(env!("CARGO_PKG_VERSION"))

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,14 +6,14 @@ use std::time::Duration;
 use termion::event::Key;
 use termion::input::TermRead;
 
-/* Terminal event methods */
+/// Terminal event methods 
 pub enum Event<I> {
 	Input(I),
 	Kernel(String),
 	Tick,
 }
 
-/* Terminal events */
+/// Terminal events 
 #[allow(dead_code)]
 pub struct Events {
 	pub tx: mpsc::Sender<Event<Key>>,
@@ -24,19 +24,19 @@ pub struct Events {
 }
 
 impl Events {
-	/**
-	 * Create a new events instance.
-	 *
-	 * @param  refresh_rate
-	 * @param  kernel_logs
-	 * @return Events
-	 */
+	
+	/// Create a new events instance.
+	 
+	/// @param  refresh_rate
+	/// @param  kernel_logs
+	/// @return Events
+	 
 	pub fn new(refresh_rate: u64, kernel_logs: &KernelLogs) -> Self {
-		/* Convert refresh rate to Duration from milliseconds. */
+		/// Convert refresh rate to Duration from milliseconds. 
 		let refresh_rate = Duration::from_millis(refresh_rate);
-		/* Create a new asynchronous channel. */
+		/// Create a new asynchronous channel. 
 		let (tx, rx) = mpsc::channel();
-		/* Handle inputs using stdin stream and sender of the channel. */
+		/// Handle inputs using stdin stream and sender of the channel. 
 		let input_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || {
@@ -46,7 +46,7 @@ impl Events {
 				}
 			})
 		};
-		/* Handle kernel logs using 'dmesg' output. */
+		/// Handle kernel logs using 'dmesg' output. 
 		let kernel_handler = {
 			let tx = tx.clone();
 			let mut kernel_logs = kernel_logs.clone();
@@ -58,7 +58,7 @@ impl Events {
 				thread::sleep(refresh_rate * 10);
 			})
 		};
-		/* Create a loop for handling events. */
+		/// Create a loop for handling events. 
 		let tick_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || loop {
@@ -66,7 +66,7 @@ impl Events {
 				thread::sleep(refresh_rate);
 			})
 		};
-		/* Return events. */
+		/// Return events. 
 		Self {
 			tx,
 			rx,

--- a/src/event.rs
+++ b/src/event.rs
@@ -27,10 +27,7 @@ impl Events {
 	
 	/// Create a new events instance.
 	 
-	/// @param  refresh_rate
-	/// @param  kernel_logs
-	/// @return Events
-	 
+
 	pub fn new(refresh_rate: u64, kernel_logs: &KernelLogs) -> Self {
 		/// Convert refresh rate to Duration from milliseconds. 
 		let refresh_rate = Duration::from_millis(refresh_rate);

--- a/src/event.rs
+++ b/src/event.rs
@@ -27,11 +27,11 @@ impl Events {
 	
 	/// Create a new events instance.
 	pub fn new(refresh_rate: u64, kernel_logs: &KernelLogs) -> Self {
-		/// Convert refresh rate to Duration from milliseconds. 
+		// Convert refresh rate to Duration from milliseconds. 
 		let refresh_rate = Duration::from_millis(refresh_rate);
-		/// Create a new asynchronous channel. 
+		// Create a new asynchronous channel. 
 		let (tx, rx) = mpsc::channel();
-		/// Handle inputs using stdin stream and sender of the channel. 
+		// Handle inputs using stdin stream and sender of the channel. 
 		let input_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || {
@@ -41,7 +41,7 @@ impl Events {
 				}
 			})
 		};
-		/// Handle kernel logs using 'dmesg' output. 
+		// Handle kernel logs using 'dmesg' output. 
 		let kernel_handler = {
 			let tx = tx.clone();
 			let mut kernel_logs = kernel_logs.clone();
@@ -53,7 +53,7 @@ impl Events {
 				thread::sleep(refresh_rate * 10);
 			})
 		};
-		/// Create a loop for handling events. 
+		// Create a loop for handling events. 
 		let tick_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || loop {
@@ -61,7 +61,7 @@ impl Events {
 				thread::sleep(refresh_rate);
 			})
 		};
-		/// Return events. 
+		// Return events. 
 		Self {
 			tx,
 			rx,

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,8 +26,6 @@ pub struct Events {
 impl Events {
 	
 	/// Create a new events instance.
-	 
-
 	pub fn new(refresh_rate: u64, kernel_logs: &KernelLogs) -> Self {
 		/// Convert refresh rate to Duration from milliseconds. 
 		let refresh_rate = Duration::from_millis(refresh_rate);

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,14 +6,14 @@ use std::time::Duration;
 use termion::event::Key;
 use termion::input::TermRead;
 
-/// Terminal event methods 
+/// Terminal event methods
 pub enum Event<I> {
 	Input(I),
 	Kernel(String),
 	Tick,
 }
 
-/// Terminal events 
+/// Terminal events
 #[allow(dead_code)]
 pub struct Events {
 	pub tx: mpsc::Sender<Event<Key>>,
@@ -24,14 +24,13 @@ pub struct Events {
 }
 
 impl Events {
-	
 	/// Create a new events instance.
 	pub fn new(refresh_rate: u64, kernel_logs: &KernelLogs) -> Self {
-		// Convert refresh rate to Duration from milliseconds. 
+		// Convert refresh rate to Duration from milliseconds.
 		let refresh_rate = Duration::from_millis(refresh_rate);
-		// Create a new asynchronous channel. 
+		// Create a new asynchronous channel.
 		let (tx, rx) = mpsc::channel();
-		// Handle inputs using stdin stream and sender of the channel. 
+		// Handle inputs using stdin stream and sender of the channel.
 		let input_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || {
@@ -41,7 +40,7 @@ impl Events {
 				}
 			})
 		};
-		// Handle kernel logs using 'dmesg' output. 
+		// Handle kernel logs using 'dmesg' output.
 		let kernel_handler = {
 			let tx = tx.clone();
 			let mut kernel_logs = kernel_logs.clone();
@@ -53,7 +52,7 @@ impl Events {
 				thread::sleep(refresh_rate * 10);
 			})
 		};
-		// Create a loop for handling events. 
+		// Create a loop for handling events.
 		let tick_handler = {
 			let tx = tx.clone();
 			thread::spawn(move || loop {
@@ -61,7 +60,7 @@ impl Events {
 				thread::sleep(refresh_rate);
 			})
 		};
-		// Return events. 
+		// Return events.
 		Self {
 			tx,
 			rx,

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -1,6 +1,6 @@
 use crate::style::Symbol;
 
-/// Kernel module related command 
+/// Kernel module related command
 #[derive(Debug)]
 pub struct Command {
 	pub cmd: String,
@@ -10,7 +10,6 @@ pub struct Command {
 }
 
 impl Command {
-	
 	/// Create a new command instance.
 	fn new(
 		cmd: String,
@@ -18,7 +17,7 @@ impl Command {
 		mut title: String,
 		symbol: Symbol,
 	) -> Self {
-		// Parse the command title if '!' is given. 
+		// Parse the command title if '!' is given.
 		if title.contains('!') {
 			title = (*title
 				.split('!')
@@ -36,7 +35,7 @@ impl Command {
 	}
 }
 
-/// Kernel module management commands 
+/// Kernel module management commands
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ModuleCommand {
 	None,
@@ -62,7 +61,6 @@ impl TryFrom<String> for ModuleCommand {
 }
 
 impl ModuleCommand {
-	
 	/// Get Command struct from a enum element.
 	pub fn get(self, module_name: &str) -> Command {
 		match self {
@@ -120,13 +118,11 @@ impl ModuleCommand {
         }
 	}
 
-	
 	/// Check if module command is set.
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
 
-	
 	/// Check if module name is a filename with suffix 'ko'
 	pub fn is_module_filename(module_name: &str) -> bool {
 		match module_name.split('.').collect::<Vec<&str>>().last() {

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -13,10 +13,6 @@ impl Command {
 	
 	/// Create a new command instance.
 	
-	/// @param  command
-	/// @param  description
-	/// @param  command_title
-	/// @return Command
 	
 	fn new(
 		cmd: String,
@@ -71,8 +67,6 @@ impl ModuleCommand {
 	
 	/// Get Command struct from a enum element.
 	 
-	/// @param  module_name
-	/// @return Command
 	
 	pub fn get(self, module_name: &str) -> Command {
 		match self {
@@ -133,7 +127,7 @@ impl ModuleCommand {
 	
 	/// Check if module command is set.
 	
-	/// @return bool
+
 	
 	pub fn is_none(self) -> bool {
 		self == Self::None
@@ -142,7 +136,7 @@ impl ModuleCommand {
 	
 	/// Check if module name is a filename with suffix 'ko'
 	 
-	/// @return bool
+
 	
 	pub fn is_module_filename(module_name: &str) -> bool {
 		match module_name.split('.').collect::<Vec<&str>>().last() {

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -12,8 +12,6 @@ pub struct Command {
 impl Command {
 	
 	/// Create a new command instance.
-	
-	
 	fn new(
 		cmd: String,
 		desc: &'static str,
@@ -66,8 +64,6 @@ impl TryFrom<String> for ModuleCommand {
 impl ModuleCommand {
 	
 	/// Get Command struct from a enum element.
-	 
-	
 	pub fn get(self, module_name: &str) -> Command {
 		match self {
             Self::None => Command::new(String::from(""), "", format!("Module: {module_name}"), Symbol::None),
@@ -126,18 +122,12 @@ impl ModuleCommand {
 
 	
 	/// Check if module command is set.
-	
-
-	
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
 
 	
 	/// Check if module name is a filename with suffix 'ko'
-	 
-
-	
 	pub fn is_module_filename(module_name: &str) -> bool {
 		match module_name.split('.').collect::<Vec<&str>>().last() {
 			Some(v) => *v == "ko",

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -18,7 +18,7 @@ impl Command {
 		mut title: String,
 		symbol: Symbol,
 	) -> Self {
-		/// Parse the command title if '!' is given. 
+		// Parse the command title if '!' is given. 
 		if title.contains('!') {
 			title = (*title
 				.split('!')

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -1,6 +1,6 @@
 use crate::style::Symbol;
 
-/* Kernel module related command */
+/// Kernel module related command 
 #[derive(Debug)]
 pub struct Command {
 	pub cmd: String,
@@ -10,21 +10,21 @@ pub struct Command {
 }
 
 impl Command {
-	/**
-	 * Create a new command instance.
-	 *
-	 * @param  command
-	 * @param  description
-	 * @param  command_title
-	 * @return Command
-	 */
+	
+	/// Create a new command instance.
+	
+	/// @param  command
+	/// @param  description
+	/// @param  command_title
+	/// @return Command
+	
 	fn new(
 		cmd: String,
 		desc: &'static str,
 		mut title: String,
 		symbol: Symbol,
 	) -> Self {
-		/* Parse the command title if '!' is given. */
+		/// Parse the command title if '!' is given. 
 		if title.contains('!') {
 			title = (*title
 				.split('!')
@@ -42,7 +42,7 @@ impl Command {
 	}
 }
 
-/* Kernel module management commands */
+/// Kernel module management commands 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ModuleCommand {
 	None,
@@ -68,12 +68,12 @@ impl TryFrom<String> for ModuleCommand {
 }
 
 impl ModuleCommand {
-	/**
-	 * Get Command struct from a enum element.
-	 *
-	 * @param  module_name
-	 * @return Command
-	 */
+	
+	/// Get Command struct from a enum element.
+	 
+	/// @param  module_name
+	/// @return Command
+	
 	pub fn get(self, module_name: &str) -> Command {
 		match self {
             Self::None => Command::new(String::from(""), "", format!("Module: {module_name}"), Symbol::None),
@@ -130,20 +130,20 @@ impl ModuleCommand {
         }
 	}
 
-	/**
-	 * Check if module command is set.
-	 *
-	 * @return bool
-	 */
+	
+	/// Check if module command is set.
+	
+	/// @return bool
+	
 	pub fn is_none(self) -> bool {
 		self == Self::None
 	}
 
-	/**
-	 * Check if module name is a filename with suffix 'ko'
-	 *
-	 * @return bool
-	 */
+	
+	/// Check if module name is a filename with suffix 'ko'
+	 
+	/// @return bool
+	
 	pub fn is_module_filename(module_name: &str) -> bool {
 		match module_name.split('.').collect::<Vec<&str>>().last() {
 			Some(v) => *v == "ko",

--- a/src/kernel/info.rs
+++ b/src/kernel/info.rs
@@ -17,7 +17,7 @@ impl KernelInfo {
 	
 	/// Create a new kernel info instance.
 	 
-	/// @return KernelInfo
+
 	
 	pub fn new() -> Self {
 		let mut kernel_info = Self {
@@ -47,7 +47,7 @@ impl KernelInfo {
 
 	/// Execute 'uname' command and return its output along with its description.
 	 
-	/// @return Iterator
+
 	 
 	fn get_infos() -> IntoIter<Vec<String>> {
 		vec![

--- a/src/kernel/info.rs
+++ b/src/kernel/info.rs
@@ -1,7 +1,7 @@
 use crate::util;
 use std::vec::IntoIter;
 
-/// Kernel and system information 
+/// Kernel and system information
 pub struct KernelInfo {
 	pub current_info: Vec<String>,
 	uname_output: IntoIter<Vec<String>>,
@@ -14,7 +14,6 @@ impl Default for KernelInfo {
 }
 
 impl KernelInfo {
-	
 	/// Create a new kernel info instance.
 	pub fn new() -> Self {
 		let mut kernel_info = Self {
@@ -25,13 +24,12 @@ impl KernelInfo {
 		kernel_info
 	}
 
-	/// Refresh the kernel information fields. 
+	/// Refresh the kernel information fields.
 	pub fn refresh(&mut self) {
 		self.uname_output = KernelInfo::get_infos();
 		self.next();
 	}
 
-	
 	/// Select the next 'uname' output as kernel information.
 	pub fn next(&mut self) {
 		match self.uname_output.next() {
@@ -39,7 +37,6 @@ impl KernelInfo {
 			None => self.refresh(),
 		}
 	}
-
 
 	/// Execute 'uname' command and return its output along with its description.
 	fn get_infos() -> IntoIter<Vec<String>> {

--- a/src/kernel/info.rs
+++ b/src/kernel/info.rs
@@ -16,9 +16,6 @@ impl Default for KernelInfo {
 impl KernelInfo {
 	
 	/// Create a new kernel info instance.
-	 
-
-	
 	pub fn new() -> Self {
 		let mut kernel_info = Self {
 			current_info: Vec::new(),
@@ -36,7 +33,6 @@ impl KernelInfo {
 
 	
 	/// Select the next 'uname' output as kernel information.
-	 
 	pub fn next(&mut self) {
 		match self.uname_output.next() {
 			Some(v) => self.current_info = v,
@@ -46,9 +42,6 @@ impl KernelInfo {
 
 
 	/// Execute 'uname' command and return its output along with its description.
-	 
-
-	 
 	fn get_infos() -> IntoIter<Vec<String>> {
 		vec![
 			vec![

--- a/src/kernel/info.rs
+++ b/src/kernel/info.rs
@@ -1,7 +1,7 @@
 use crate::util;
 use std::vec::IntoIter;
 
-/* Kernel and system information */
+/// Kernel and system information 
 pub struct KernelInfo {
 	pub current_info: Vec<String>,
 	uname_output: IntoIter<Vec<String>>,
@@ -14,11 +14,11 @@ impl Default for KernelInfo {
 }
 
 impl KernelInfo {
-	/**
-	 * Create a new kernel info instance.
-	 *
-	 * @return KernelInfo
-	 */
+	
+	/// Create a new kernel info instance.
+	 
+	/// @return KernelInfo
+	
 	pub fn new() -> Self {
 		let mut kernel_info = Self {
 			current_info: Vec::new(),
@@ -28,15 +28,15 @@ impl KernelInfo {
 		kernel_info
 	}
 
-	/* Refresh the kernel information fields. */
+	/// Refresh the kernel information fields. 
 	pub fn refresh(&mut self) {
 		self.uname_output = KernelInfo::get_infos();
 		self.next();
 	}
 
-	/**
-	 * Select the next 'uname' output as kernel information.
-	 */
+	
+	/// Select the next 'uname' output as kernel information.
+	 
 	pub fn next(&mut self) {
 		match self.uname_output.next() {
 			Some(v) => self.current_info = v,
@@ -44,11 +44,11 @@ impl KernelInfo {
 		}
 	}
 
-	/**
-	 * Execute 'uname' command and return its output along with its description.
-	 *
-	 * @return Iterator
-	 */
+
+	/// Execute 'uname' command and return its output along with its description.
+	 
+	/// @return Iterator
+	 
 	fn get_infos() -> IntoIter<Vec<String>> {
 		vec![
 			vec![

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -21,7 +21,7 @@ impl SortType {
 	
 	/// Return iterator for the sort types.
 	
-	/// @return Iter
+
 	
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, SortType> {
@@ -45,8 +45,7 @@ impl ListArgs {
 	
 	/// Create a new list arguments instance.
 	
-	/// @param  ArgMatches
-	/// @return ListArgs
+
 	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut sort_type = SortType::None;
@@ -84,9 +83,6 @@ impl KernelModules<'_> {
 	
 	/// Create a new kernel modules instance.
 	 
-	/// @param  ListArgs
-	/// @param  Style
-	/// @return KernelModules
 	
 	pub fn new(args: ListArgs, style: Style) -> Self {
 		let mut kernel_modules = Self {
@@ -147,7 +143,7 @@ impl KernelModules<'_> {
 	
 	/// Get the current command using current module name.
 	 
-	/// @return Command
+
 	
 	pub fn get_current_command(&self) -> Command {
 		self.command.get(&self.current_name)
@@ -156,8 +152,6 @@ impl KernelModules<'_> {
 	
 	/// Set the current module command and show confirmation message.
 	 
-	/// @param module_command
-	/// @param command_name
 	
 	pub fn set_current_command(
 		&mut self,
@@ -200,7 +194,7 @@ impl KernelModules<'_> {
 	
 	/// Execute the current module command.
 	
-	/// @return command_executed
+
 	
 	pub fn execute_command(&mut self) -> bool {
 		let mut command_executed = false;
@@ -245,7 +239,7 @@ impl KernelModules<'_> {
 	
 	/// Cancel the execution of the current command.
 	
-	/// @return cancelled
+
 	 
 	pub fn cancel_execution(&mut self) -> bool {
 		if !self.command.is_none() {
@@ -266,7 +260,6 @@ impl KernelModules<'_> {
 	
 	/// Scroll to the position of used module at given index.
 	
-	/// @param mod_index
 	
 	pub fn show_used_module(&mut self, mod_index: usize) {
 		if let Some(used_module) = self.list[self.index][2]
@@ -301,7 +294,6 @@ impl KernelModules<'_> {
 	
 	/// Scroll module list up/down and select module.
 	 
-	/// @param direction
 	
 	pub fn scroll_list(&mut self, direction: ScrollDirection) {
 		self.info_scroll_offset = 0;
@@ -367,8 +359,6 @@ impl KernelModules<'_> {
 	
 	/// Scroll the module information text up/down.
 	
-	/// @param direction
-	/// @param smooth_scroll
 	
 	pub fn scroll_mod_info(
 		&mut self,

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -8,7 +8,7 @@ use ratatui::text::{Line, Span, Text};
 use std::error::Error;
 use std::slice::Iter;
 
-/* Type of the sorting of module list */
+/// Type of the sorting of module list 
 #[derive(Clone, Copy, Debug)]
 enum SortType {
 	None,
@@ -18,11 +18,11 @@ enum SortType {
 }
 
 impl SortType {
-	/**
-	 * Return iterator for the sort types.
-	 *
-	 * @return Iter
-	 */
+	
+	/// Return iterator for the sort types.
+	
+	/// @return Iter
+	
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, SortType> {
 		[
@@ -35,19 +35,19 @@ impl SortType {
 	}
 }
 
-/* Listing properties of module list */
+/// Listing properties of module list 
 pub struct ListArgs {
 	sort: SortType,
 	reverse: bool,
 }
 
 impl ListArgs {
-	/**
-	 * Create a new list arguments instance.
-	 *
-	 * @param  ArgMatches
-	 * @return ListArgs
-	 */
+	
+	/// Create a new list arguments instance.
+	
+	/// @param  ArgMatches
+	/// @return ListArgs
+	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut sort_type = SortType::None;
 		if let Some(("sort", matches)) = args.subcommand() {
@@ -67,7 +67,7 @@ impl ListArgs {
 	}
 }
 
-/* Loadable kernel modules */
+/// Loadable kernel modules 
 pub struct KernelModules<'a> {
 	pub default_list: Vec<Vec<String>>,
 	pub list: Vec<Vec<String>>,
@@ -81,13 +81,13 @@ pub struct KernelModules<'a> {
 }
 
 impl KernelModules<'_> {
-	/**
-	 * Create a new kernel modules instance.
-	 *
-	 * @param  ListArgs
-	 * @param  Style
-	 * @return KernelModules
-	 */
+	
+	/// Create a new kernel modules instance.
+	 
+	/// @param  ListArgs
+	/// @param  Style
+	/// @return KernelModules
+	
 	pub fn new(args: ListArgs, style: Style) -> Self {
 		let mut kernel_modules = Self {
 			default_list: Vec::new(),
@@ -106,10 +106,10 @@ impl KernelModules<'_> {
 		kernel_modules
 	}
 
-	/* Parse kernel modules from '/proc/modules'. */
+	/// Parse kernel modules from '/proc/modules'. 
 	pub fn refresh(&mut self) -> Result<(), Box<dyn Error>> {
 		let mut module_list: Vec<Vec<String>> = Vec::new();
-		/* Set the command for reading kernel modules and execute it. */
+		/// Set the command for reading kernel modules and execute it.
 		let mut module_read_cmd = String::from("cat /proc/modules");
 		match self.args.sort {
 			SortType::Size => module_read_cmd += " | sort -n -r -t ' ' -k2",
@@ -119,7 +119,7 @@ impl KernelModules<'_> {
 		}
 		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])?;
 
-		/* Parse content for module name, size and related information. */
+		/// Parse content for module name, size and related information. 
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();
 			let mut module_name = format!(" {}", columns[0]);
@@ -134,7 +134,7 @@ impl KernelModules<'_> {
 				ByteSize::b(columns[1].to_string().parse().unwrap_or(0)).to_string();
 			module_list.push(vec![module_name, module_size, used_modules]);
 		}
-		/* Reverse the kernel modules if the argument is provided. */
+		/// Reverse the kernel modules if the argument is provided. 
 		if self.args.reverse {
 			module_list.reverse();
 		}
@@ -144,21 +144,21 @@ impl KernelModules<'_> {
 		Ok(())
 	}
 
-	/**
-	 * Get the current command using current module name.
-	 *
-	 * @return Command
-	 */
+	
+	/// Get the current command using current module name.
+	 
+	/// @return Command
+	
 	pub fn get_current_command(&self) -> Command {
 		self.command.get(&self.current_name)
 	}
 
-	/**
-	 * Set the current module command and show confirmation message.
-	 *
-	 * @param module_command
-	 * @param command_name
-	 */
+	
+	/// Set the current module command and show confirmation message.
+	 
+	/// @param module_command
+	/// @param command_name
+	
 	pub fn set_current_command(
 		&mut self,
 		module_command: ModuleCommand,
@@ -197,11 +197,11 @@ impl KernelModules<'_> {
 		}
 	}
 
-	/**
-	 * Execute the current module command.
-	 *
-	 * @return command_executed
-	 */
+	
+	/// Execute the current module command.
+	
+	/// @return command_executed
+	
 	pub fn execute_command(&mut self) -> bool {
 		let mut command_executed = false;
 		if !self.command.is_none() {
@@ -242,11 +242,11 @@ impl KernelModules<'_> {
 		command_executed
 	}
 
-	/**
-	 * Cancel the execution of the current command.
-	 *
-	 * @return cancelled
-	 */
+	
+	/// Cancel the execution of the current command.
+	
+	/// @return cancelled
+	 
 	pub fn cancel_execution(&mut self) -> bool {
 		if !self.command.is_none() {
 			self.command = ModuleCommand::None;
@@ -263,11 +263,11 @@ impl KernelModules<'_> {
 		}
 	}
 
-	/**
-	 * Scroll to the position of used module at given index.
-	 *
-	 * @param mod_index
-	 */
+	
+	/// Scroll to the position of used module at given index.
+	
+	/// @param mod_index
+	
 	pub fn show_used_module(&mut self, mod_index: usize) {
 		if let Some(used_module) = self.list[self.index][2]
 			.split(' ')
@@ -298,17 +298,17 @@ impl KernelModules<'_> {
 		}
 	}
 
-	/**
-	 * Scroll module list up/down and select module.
-	 *
-	 * @param direction
-	 */
+	
+	/// Scroll module list up/down and select module.
+	 
+	/// @param direction
+	
 	pub fn scroll_list(&mut self, direction: ScrollDirection) {
 		self.info_scroll_offset = 0;
 		if self.list.is_empty() {
 			self.index = 0;
 		} else {
-			/* Scroll module list. */
+			/// Scroll module list. 
 			match direction {
 				ScrollDirection::Up => self.previous_module(),
 				ScrollDirection::Down => self.next_module(),
@@ -316,14 +316,14 @@ impl KernelModules<'_> {
 				ScrollDirection::Bottom => self.index = self.list.len() - 1,
 				_ => {}
 			}
-			/* Set current module name. */
+			/// Set current module name. 
 			self.current_name = self.list[self.index][0]
 				.split_whitespace()
 				.next()
 				.unwrap_or("?")
 				.trim()
 				.to_string();
-			/* Execute 'modinfo' and add style to its output. */
+			/// Execute 'modinfo' and add style to its output. 
 			self.current_info.stylize_data(
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
@@ -336,16 +336,16 @@ impl KernelModules<'_> {
 				":",
 				self.style.clone(),
 			);
-			/* Clear the current command. */
+			/// Clear the current command. 
 			if !self.command.is_none() {
 				self.command = ModuleCommand::None;
 			}
 		}
 	}
 
-	/**
-	 * Select the next module.
-	 */
+	
+	/// Select the next module.
+	
 	pub fn next_module(&mut self) {
 		self.index += 1;
 		if self.index > self.list.len() - 1 {
@@ -353,9 +353,9 @@ impl KernelModules<'_> {
 		}
 	}
 
-	/**
-	 * Select the previous module.
-	 */
+	
+	/// Select the previous module.
+	
 	pub fn previous_module(&mut self) {
 		if self.index > 0 {
 			self.index -= 1;
@@ -364,12 +364,12 @@ impl KernelModules<'_> {
 		}
 	}
 
-	/**
-	 * Scroll the module information text up/down.
-	 *
-	 * @param direction
-	 * @param smooth_scroll
-	 */
+	
+	/// Scroll the module information text up/down.
+	
+	/// @param direction
+	/// @param smooth_scroll
+	
 	pub fn scroll_mod_info(
 		&mut self,
 		direction: ScrollDirection,

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -8,7 +8,7 @@ use ratatui::text::{Line, Span, Text};
 use std::error::Error;
 use std::slice::Iter;
 
-/// Type of the sorting of module list 
+/// Type of the sorting of module list
 #[derive(Clone, Copy, Debug)]
 enum SortType {
 	None,
@@ -18,7 +18,6 @@ enum SortType {
 }
 
 impl SortType {
-	
 	/// Return iterator for the sort types.
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, SortType> {
@@ -32,14 +31,13 @@ impl SortType {
 	}
 }
 
-/// Listing properties of module list 
+/// Listing properties of module list
 pub struct ListArgs {
 	sort: SortType,
 	reverse: bool,
 }
 
 impl ListArgs {
-	
 	/// Create a new list arguments instance.
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut sort_type = SortType::None;
@@ -60,7 +58,7 @@ impl ListArgs {
 	}
 }
 
-/// Loadable kernel modules 
+/// Loadable kernel modules
 pub struct KernelModules<'a> {
 	pub default_list: Vec<Vec<String>>,
 	pub list: Vec<Vec<String>>,
@@ -74,7 +72,6 @@ pub struct KernelModules<'a> {
 }
 
 impl KernelModules<'_> {
-	
 	/// Create a new kernel modules instance.
 	pub fn new(args: ListArgs, style: Style) -> Self {
 		let mut kernel_modules = Self {
@@ -94,7 +91,7 @@ impl KernelModules<'_> {
 		kernel_modules
 	}
 
-	/// Parse kernel modules from '/proc/modules'. 
+	/// Parse kernel modules from '/proc/modules'.
 	pub fn refresh(&mut self) -> Result<(), Box<dyn Error>> {
 		let mut module_list: Vec<Vec<String>> = Vec::new();
 		// Set the command for reading kernel modules and execute it.
@@ -107,7 +104,7 @@ impl KernelModules<'_> {
 		}
 		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])?;
 
-		// Parse content for module name, size and related information. 
+		// Parse content for module name, size and related information.
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();
 			let mut module_name = format!(" {}", columns[0]);
@@ -122,7 +119,7 @@ impl KernelModules<'_> {
 				ByteSize::b(columns[1].to_string().parse().unwrap_or(0)).to_string();
 			module_list.push(vec![module_name, module_size, used_modules]);
 		}
-		// Reverse the kernel modules if the argument is provided. 
+		// Reverse the kernel modules if the argument is provided.
 		if self.args.reverse {
 			module_list.reverse();
 		}
@@ -132,13 +129,11 @@ impl KernelModules<'_> {
 		Ok(())
 	}
 
-	
 	/// Get the current command using current module name.
 	pub fn get_current_command(&self) -> Command {
 		self.command.get(&self.current_name)
 	}
 
-	
 	/// Set the current module command and show confirmation message.
 	pub fn set_current_command(
 		&mut self,
@@ -178,7 +173,6 @@ impl KernelModules<'_> {
 		}
 	}
 
-	
 	/// Execute the current module command.
 	pub fn execute_command(&mut self) -> bool {
 		let mut command_executed = false;
@@ -220,7 +214,6 @@ impl KernelModules<'_> {
 		command_executed
 	}
 
-	
 	/// Cancel the execution of the current command.
 	pub fn cancel_execution(&mut self) -> bool {
 		if !self.command.is_none() {
@@ -238,7 +231,6 @@ impl KernelModules<'_> {
 		}
 	}
 
-	
 	/// Scroll to the position of used module at given index.
 	pub fn show_used_module(&mut self, mod_index: usize) {
 		if let Some(used_module) = self.list[self.index][2]
@@ -270,14 +262,13 @@ impl KernelModules<'_> {
 		}
 	}
 
-	
 	/// Scroll module list up/down and select module.
 	pub fn scroll_list(&mut self, direction: ScrollDirection) {
 		self.info_scroll_offset = 0;
 		if self.list.is_empty() {
 			self.index = 0;
 		} else {
-			// Scroll module list. 
+			// Scroll module list.
 			match direction {
 				ScrollDirection::Up => self.previous_module(),
 				ScrollDirection::Down => self.next_module(),
@@ -285,14 +276,14 @@ impl KernelModules<'_> {
 				ScrollDirection::Bottom => self.index = self.list.len() - 1,
 				_ => {}
 			}
-			// Set current module name. 
+			// Set current module name.
 			self.current_name = self.list[self.index][0]
 				.split_whitespace()
 				.next()
 				.unwrap_or("?")
 				.trim()
 				.to_string();
-			// Execute 'modinfo' and add style to its output. 
+			// Execute 'modinfo' and add style to its output.
 			self.current_info.stylize_data(
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
@@ -305,14 +296,13 @@ impl KernelModules<'_> {
 				":",
 				self.style.clone(),
 			);
-			// Clear the current command. 
+			// Clear the current command.
 			if !self.command.is_none() {
 				self.command = ModuleCommand::None;
 			}
 		}
 	}
 
-	
 	/// Select the next module.
 	pub fn next_module(&mut self) {
 		self.index += 1;
@@ -321,7 +311,6 @@ impl KernelModules<'_> {
 		}
 	}
 
-	
 	/// Select the previous module.
 	pub fn previous_module(&mut self) {
 		if self.index > 0 {
@@ -331,7 +320,6 @@ impl KernelModules<'_> {
 		}
 	}
 
-	
 	/// Scroll the module information text up/down.
 	pub fn scroll_mod_info(
 		&mut self,

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -97,7 +97,7 @@ impl KernelModules<'_> {
 	/// Parse kernel modules from '/proc/modules'. 
 	pub fn refresh(&mut self) -> Result<(), Box<dyn Error>> {
 		let mut module_list: Vec<Vec<String>> = Vec::new();
-		/// Set the command for reading kernel modules and execute it.
+		// Set the command for reading kernel modules and execute it.
 		let mut module_read_cmd = String::from("cat /proc/modules");
 		match self.args.sort {
 			SortType::Size => module_read_cmd += " | sort -n -r -t ' ' -k2",
@@ -107,7 +107,7 @@ impl KernelModules<'_> {
 		}
 		let modules_content = util::exec_cmd("sh", &["-c", &module_read_cmd])?;
 
-		/// Parse content for module name, size and related information. 
+		// Parse content for module name, size and related information. 
 		for line in modules_content.lines() {
 			let columns: Vec<&str> = line.split_whitespace().collect();
 			let mut module_name = format!(" {}", columns[0]);
@@ -122,7 +122,7 @@ impl KernelModules<'_> {
 				ByteSize::b(columns[1].to_string().parse().unwrap_or(0)).to_string();
 			module_list.push(vec![module_name, module_size, used_modules]);
 		}
-		/// Reverse the kernel modules if the argument is provided. 
+		// Reverse the kernel modules if the argument is provided. 
 		if self.args.reverse {
 			module_list.reverse();
 		}
@@ -277,7 +277,7 @@ impl KernelModules<'_> {
 		if self.list.is_empty() {
 			self.index = 0;
 		} else {
-			/// Scroll module list. 
+			// Scroll module list. 
 			match direction {
 				ScrollDirection::Up => self.previous_module(),
 				ScrollDirection::Down => self.next_module(),
@@ -285,14 +285,14 @@ impl KernelModules<'_> {
 				ScrollDirection::Bottom => self.index = self.list.len() - 1,
 				_ => {}
 			}
-			/// Set current module name. 
+			// Set current module name. 
 			self.current_name = self.list[self.index][0]
 				.split_whitespace()
 				.next()
 				.unwrap_or("?")
 				.trim()
 				.to_string();
-			/// Execute 'modinfo' and add style to its output. 
+			// Execute 'modinfo' and add style to its output. 
 			self.current_info.stylize_data(
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
@@ -305,7 +305,7 @@ impl KernelModules<'_> {
 				":",
 				self.style.clone(),
 			);
-			/// Clear the current command. 
+			// Clear the current command. 
 			if !self.command.is_none() {
 				self.command = ModuleCommand::None;
 			}

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -20,9 +20,6 @@ enum SortType {
 impl SortType {
 	
 	/// Return iterator for the sort types.
-	
-
-	
 	#[allow(dead_code)]
 	pub fn iter() -> Iter<'static, SortType> {
 		[
@@ -44,9 +41,6 @@ pub struct ListArgs {
 impl ListArgs {
 	
 	/// Create a new list arguments instance.
-	
-
-	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut sort_type = SortType::None;
 		if let Some(("sort", matches)) = args.subcommand() {
@@ -82,8 +76,6 @@ pub struct KernelModules<'a> {
 impl KernelModules<'_> {
 	
 	/// Create a new kernel modules instance.
-	 
-	
 	pub fn new(args: ListArgs, style: Style) -> Self {
 		let mut kernel_modules = Self {
 			default_list: Vec::new(),
@@ -142,17 +134,12 @@ impl KernelModules<'_> {
 
 	
 	/// Get the current command using current module name.
-	 
-
-	
 	pub fn get_current_command(&self) -> Command {
 		self.command.get(&self.current_name)
 	}
 
 	
 	/// Set the current module command and show confirmation message.
-	 
-	
 	pub fn set_current_command(
 		&mut self,
 		module_command: ModuleCommand,
@@ -193,9 +180,6 @@ impl KernelModules<'_> {
 
 	
 	/// Execute the current module command.
-	
-
-	
 	pub fn execute_command(&mut self) -> bool {
 		let mut command_executed = false;
 		if !self.command.is_none() {
@@ -238,9 +222,6 @@ impl KernelModules<'_> {
 
 	
 	/// Cancel the execution of the current command.
-	
-
-	 
 	pub fn cancel_execution(&mut self) -> bool {
 		if !self.command.is_none() {
 			self.command = ModuleCommand::None;
@@ -259,8 +240,6 @@ impl KernelModules<'_> {
 
 	
 	/// Scroll to the position of used module at given index.
-	
-	
 	pub fn show_used_module(&mut self, mod_index: usize) {
 		if let Some(used_module) = self.list[self.index][2]
 			.split(' ')
@@ -293,8 +272,6 @@ impl KernelModules<'_> {
 
 	
 	/// Scroll module list up/down and select module.
-	 
-	
 	pub fn scroll_list(&mut self, direction: ScrollDirection) {
 		self.info_scroll_offset = 0;
 		if self.list.is_empty() {
@@ -337,7 +314,6 @@ impl KernelModules<'_> {
 
 	
 	/// Select the next module.
-	
 	pub fn next_module(&mut self) {
 		self.index += 1;
 		if self.index > self.list.len() - 1 {
@@ -347,7 +323,6 @@ impl KernelModules<'_> {
 
 	
 	/// Select the previous module.
-	
 	pub fn previous_module(&mut self) {
 		if self.index > 0 {
 			self.index -= 1;
@@ -358,8 +333,6 @@ impl KernelModules<'_> {
 
 	
 	/// Scroll the module information text up/down.
-	
-	
 	pub fn scroll_mod_info(
 		&mut self,
 		direction: ScrollDirection,

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -15,9 +15,6 @@ pub struct KernelLogs {
 impl KernelLogs {
 	
 	/// Update the output variable value if 'dmesg' logs changed.
-	 
-	
-	
 	pub fn update(&mut self) -> bool {
 		self.output = util::exec_cmd(
 			"dmesg",
@@ -45,9 +42,6 @@ impl KernelLogs {
 
 	
 	/// Select a part of the output depending on the area properties.
-	 
-
-	
 	pub fn select(&mut self, area_height: u16, area_sub: u16) -> &str {
 		self.selected_output = self
 			.output
@@ -74,8 +68,6 @@ impl KernelLogs {
 
 	
 	/// Scroll the kernel logs up/down.
-
-	
 	pub fn scroll(&mut self, direction: ScrollDirection, smooth_scroll: bool) {
 		let scroll_amount = if smooth_scroll { 1 } else { 3 };
 		match direction {

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -2,7 +2,7 @@ use crate::app::ScrollDirection;
 use crate::util;
 use std::fmt::Write as _;
 
-/// Kernel activity logs 
+/// Kernel activity logs
 #[derive(Clone, Debug, Default)]
 pub struct KernelLogs {
 	pub output: String,
@@ -13,7 +13,6 @@ pub struct KernelLogs {
 }
 
 impl KernelLogs {
-	
 	/// Update the output variable value if 'dmesg' logs changed.
 	pub fn update(&mut self) -> bool {
 		self.output = util::exec_cmd(
@@ -32,7 +31,7 @@ impl KernelLogs {
 		logs_updated
 	}
 
-	/// Refresh the kernel logs. 
+	/// Refresh the kernel logs.
 	pub fn refresh(&mut self) {
 		self.last_line = String::new();
 		self.index = 0;
@@ -40,7 +39,6 @@ impl KernelLogs {
 		self.update();
 	}
 
-	
 	/// Select a part of the output depending on the area properties.
 	pub fn select(&mut self, area_height: u16, area_sub: u16) -> &str {
 		self.selected_output = self
@@ -66,7 +64,6 @@ impl KernelLogs {
 		&self.selected_output
 	}
 
-	
 	/// Scroll the kernel logs up/down.
 	pub fn scroll(&mut self, direction: ScrollDirection, smooth_scroll: bool) {
 		let scroll_amount = if smooth_scroll { 1 } else { 3 };

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -2,7 +2,7 @@ use crate::app::ScrollDirection;
 use crate::util;
 use std::fmt::Write as _;
 
-/* Kernel activity logs */
+/// Kernel activity logs 
 #[derive(Clone, Debug, Default)]
 pub struct KernelLogs {
 	pub output: String,
@@ -13,11 +13,11 @@ pub struct KernelLogs {
 }
 
 impl KernelLogs {
-	/**
-	 * Update the output variable value if 'dmesg' logs changed.
-	 *
-	 * @return logs_updated
-	 */
+	
+	/// Update the output variable value if 'dmesg' logs changed.
+	 
+	/// @return logs_updated
+	
 	pub fn update(&mut self) -> bool {
 		self.output = util::exec_cmd(
 			"dmesg",
@@ -35,7 +35,7 @@ impl KernelLogs {
 		logs_updated
 	}
 
-	/* Refresh the kernel logs. */
+	/// Refresh the kernel logs. 
 	pub fn refresh(&mut self) {
 		self.last_line = String::new();
 		self.index = 0;
@@ -43,13 +43,13 @@ impl KernelLogs {
 		self.update();
 	}
 
-	/**
-	 * Select a part of the output depending on the area properties.
-	 *
-	 * @param  area_height
-	 * @param  area_sub
-	 * @return selected_output
-	 */
+	
+	/// Select a part of the output depending on the area properties.
+	 
+	/// @param  area_height
+	/// @param  area_sub
+	/// @return selected_output
+	
 	pub fn select(&mut self, area_height: u16, area_sub: u16) -> &str {
 		self.selected_output = self
 			.output
@@ -74,12 +74,12 @@ impl KernelLogs {
 		&self.selected_output
 	}
 
-	/**
-	 * Scroll the kernel logs up/down.
-	 *
-	 * @param direction
-	 * @param smooth_scroll
-	 */
+	
+	/// Scroll the kernel logs up/down.
+	
+	/// @param direction
+	/// @param smooth_scroll
+	
 	pub fn scroll(&mut self, direction: ScrollDirection, smooth_scroll: bool) {
 		let scroll_amount = if smooth_scroll { 1 } else { 3 };
 		match direction {

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -16,7 +16,7 @@ impl KernelLogs {
 	
 	/// Update the output variable value if 'dmesg' logs changed.
 	 
-	/// @return logs_updated
+	
 	
 	pub fn update(&mut self) -> bool {
 		self.output = util::exec_cmd(
@@ -46,9 +46,7 @@ impl KernelLogs {
 	
 	/// Select a part of the output depending on the area properties.
 	 
-	/// @param  area_height
-	/// @param  area_sub
-	/// @return selected_output
+
 	
 	pub fn select(&mut self, area_height: u16, area_sub: u16) -> &str {
 		self.selected_output = self
@@ -76,9 +74,7 @@ impl KernelLogs {
 
 	
 	/// Scroll the kernel logs up/down.
-	
-	/// @param direction
-	/// @param smooth_scroll
+
 	
 	pub fn scroll(&mut self, direction: ScrollDirection, smooth_scroll: bool) {
 		let scroll_amount = if smooth_scroll { 1 } else { 3 };

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -8,7 +8,7 @@ use info::KernelInfo;
 use lkm::{KernelModules, ListArgs};
 use log::KernelLogs;
 
-/// Kernel struct for logs, information and modules 
+/// Kernel struct for logs, information and modules
 pub struct Kernel {
 	pub logs: KernelLogs,
 	pub info: KernelInfo,
@@ -16,7 +16,6 @@ pub struct Kernel {
 }
 
 impl Kernel {
-	
 	/// Create a new kernel instance.
 	pub fn new(args: &ArgMatches) -> Self {
 		Self {
@@ -26,7 +25,7 @@ impl Kernel {
 		}
 	}
 
-	/// Refresh kernel logs, modules and information. 
+	/// Refresh kernel logs, modules and information.
 	pub fn refresh(&mut self) {
 		self.logs.refresh();
 		self.info.refresh();

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -8,7 +8,7 @@ use info::KernelInfo;
 use lkm::{KernelModules, ListArgs};
 use log::KernelLogs;
 
-/* Kernel struct for logs, information and modules */
+/// Kernel struct for logs, information and modules 
 pub struct Kernel {
 	pub logs: KernelLogs,
 	pub info: KernelInfo,
@@ -16,12 +16,12 @@ pub struct Kernel {
 }
 
 impl Kernel {
-	/**
-	 * Create a new kernel instance.
-	 *
-	 * @param  ArgMatches
-	 * @return Kernel
-	 */
+	
+	/// Create a new kernel instance.
+	 
+	/// @param  ArgMatches
+	/// @return Kernel
+	
 	pub fn new(args: &ArgMatches) -> Self {
 		Self {
 			logs: KernelLogs::default(),
@@ -30,7 +30,7 @@ impl Kernel {
 		}
 	}
 
-	/* Refresh kernel logs, modules and information. */
+	/// Refresh kernel logs, modules and information. 
 	pub fn refresh(&mut self) {
 		self.logs.refresh();
 		self.info.refresh();

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -18,8 +18,6 @@ pub struct Kernel {
 impl Kernel {
 	
 	/// Create a new kernel instance.
-	 
-	
 	pub fn new(args: &ArgMatches) -> Self {
 		Self {
 			logs: KernelLogs::default(),

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -19,8 +19,6 @@ impl Kernel {
 	
 	/// Create a new kernel instance.
 	 
-	/// @param  ArgMatches
-	/// @return Kernel
 	
 	pub fn new(args: &ArgMatches) -> Self {
 		Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,6 @@ use unicode_width::UnicodeWidthStr;
 
 
 /// Configure the terminal and draw its widgets.
- 
-
- 
 pub fn start_tui<B>(
 	mut terminal: Terminal<B>,
 	mut kernel: Kernel,
@@ -644,9 +641,6 @@ mod tests {
 	}
 	
 	/// Try to send a key event until Sender succeeds.
-	 
-
-	
 	fn send_key(tx: &Sender<Event<Key>>, key: Key) {
 		let mut x = true;
 		while x {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ pub fn start_tui<B>(
 where
 	B: Backend,
 {
-	/// Configure the application.
+	// Configure the application.
 	let mut app = App::new(Block::ModuleTable, kernel.modules.style.clone());
-	/// Draw terminal and render the widgets. 
+	// Draw terminal and render the widgets. 
 	loop {
 		terminal.draw(|frame| {
 			let chunks = Layout::default()
@@ -98,15 +98,15 @@ where
 				frame.set_cursor(1 + app.input_query.width() as u16, 1);
 			}
 		})?;
-		/// Handle terminal events. 
+		// Handle terminal events. 
 		match events.rx.recv()? {
-			/// Key input events. 
+			// Key input events. 
 			Event::Input(input) => {
 				let mut hide_options = true;
 				if app.input_mode.is_none() {
-					/// Default input mode. 
+					// Default input mode. 
 					match input {
-						/// Quit. 
+						// Quit. 
 						Key::Char('q')
 						| Key::Char('Q')
 						| Key::Ctrl('c')
@@ -118,12 +118,12 @@ where
 								break;
 							}
 						}
-						/// Refresh. 
+						// Refresh. 
 						Key::Char('r') | Key::Char('R') | Key::F(5) => {
 							app.refresh();
 							kernel.refresh();
 						}
-						/// Show help message. 
+						// Show help message. 
 						Key::Char('?') | Key::F(1) => {
 							app.show_help_message(&mut kernel.modules);
 						}
@@ -131,7 +131,7 @@ where
 							app.show_options = true;
 							hide_options = false;
 						}
-						/// Scroll the selected block up. 
+						// Scroll the selected block up. 
 						Key::Up
 						| Key::Char('k')
 						| Key::Char('K')
@@ -161,7 +161,7 @@ where
 								_ => {}
 							}
 						}
-						/// Scroll the selected block down. 
+						// Scroll the selected block down. 
 						Key::Down
 						| Key::Char('j')
 						| Key::Char('J')
@@ -191,7 +191,7 @@ where
 								_ => {}
 							}
 						}
-						/// Select the next terminal block. 
+						// Select the next terminal block. 
 						Key::Left | Key::Char('h') | Key::Char('H') => {
 							app.selected_block = match app.selected_block.previous()
 							{
@@ -199,14 +199,14 @@ where
 								None => Block::last().unwrap(),
 							}
 						}
-						/// Select the previous terminal block. 
+						// Select the previous terminal block. 
 						Key::Right | Key::Char('l') | Key::Char('L') => {
 							app.selected_block = match app.selected_block.next() {
 								Some(v) => v,
 								None => Block::first().unwrap(),
 							}
 						}
-						/// Expand the selected block. 
+						// Expand the selected block. 
 						Key::Alt('e') => {
 							let block_size = app.block_size();
 							if *block_size < 95 {
@@ -215,13 +215,13 @@ where
 								*block_size = 100;
 							}
 						}
-						/// Shrink the selected block. 
+						// Shrink the selected block. 
 						Key::Alt('s') => {
 							let block_size = app.block_size();
 							*block_size =
 								(*block_size).checked_sub(5).unwrap_or_default()
 						}
-						/// Change the block position. 
+						// Change the block position. 
 						Key::Ctrl('x') => {
 							if app.block_index == 2 {
 								app.block_index = 0;
@@ -229,61 +229,61 @@ where
 								app.block_index += 1;
 							}
 						}
-						/// Scroll to the top of the module list. 
+						// Scroll to the top of the module list. 
 						Key::Ctrl('t') | Key::Home => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Top)
 						}
-						/// Scroll to the bottom of the module list. 
+						// Scroll to the bottom of the module list. 
 						Key::Ctrl('b') | Key::End => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Bottom)
 						}
-						/// Scroll kernel activities up. 
+						// Scroll kernel activities up. 
 						Key::PageUp => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Up, false);
 						}
-						/// Scroll kernel activities down. 
+						// Scroll kernel activities down. 
 						Key::PageDown => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Down, false);
 						}
-						/// Scroll kernel activities left.
+						// Scroll kernel activities left.
 						Key::Alt('h') | Key::Alt('H') => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Left, false);
 						}
-						/// Scroll kernel activities right. 
+						// Scroll kernel activities right. 
 						Key::Alt('l') | Key::Alt('L') => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Right, false);
 						}
-						/// Scroll module information up. 
+						// Scroll module information up. 
 						Key::Char('<') | Key::Alt(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Up, false)
 						}
-						/// Scroll module information down. 
+						// Scroll module information down. 
 						Key::Char('>') | Key::Char(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Down, false)
 						}
-						/// Show the next kernel information. 
+						// Show the next kernel information. 
 						Key::Char('\\') | Key::Char('\t') | Key::BackTab => {
 							kernel.info.next();
 						}
-						/// Display the dependent modules. 
+						// Display the dependent modules. 
 						Key::Char('d') | Key::Alt('d') => {
 							app.show_dependent_modules(&mut kernel.modules);
 						}
-						/// Clear the kernel ring buffer. 
+						// Clear the kernel ring buffer. 
 						Key::Ctrl('l')
 						| Key::Ctrl('u')
 						| Key::Alt('c')
@@ -293,7 +293,7 @@ where
 								String::new(),
 							);
 						}
-						/// Unload kernel module. 
+						// Unload kernel module. 
 						Key::Char('u')
 						| Key::Char('U')
 						| Key::Char('-')
@@ -304,7 +304,7 @@ where
 								String::new(),
 							);
 						}
-						/// Blacklist kernel module. 
+						// Blacklist kernel module. 
 						Key::Char('x')
 						| Key::Char('X')
 						| Key::Char('b')
@@ -315,7 +315,7 @@ where
 								String::new(),
 							);
 						}
-						/// Reload kernel module. 
+						// Reload kernel module. 
 						Key::Ctrl('r')
 						| Key::Ctrl('R')
 						| Key::Alt('r')
@@ -325,7 +325,7 @@ where
 								String::new(),
 							);
 						}
-						/// Execute the current command. 
+						// Execute the current command. 
 						Key::Char('y') | Key::Char('Y') => {
 							if kernel.modules.execute_command() {
 								events
@@ -334,13 +334,13 @@ where
 									.unwrap();
 							}
 						}
-						/// Cancel the execution of current command. 
+						// Cancel the execution of current command. 
 						Key::Char('n') | Key::Char('N') => {
 							if kernel.modules.cancel_execution() {
 								app.selected_block = Block::ModuleTable;
 							}
 						}
-						/// Copy the data in selected block to clipboard. 
+						// Copy the data in selected block to clipboard. 
 						Key::Char('c') | Key::Char('C') => {
 							app.set_clipboard_contents(match app.selected_block {
 								Block::ModuleTable => &kernel.modules.current_name,
@@ -353,14 +353,14 @@ where
 								_ => "",
 							});
 						}
-						/// Paste the clipboard contents and switch to search mode. 
+						// Paste the clipboard contents and switch to search mode. 
 						Key::Char('v') | Key::Ctrl('V') | Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
 							kernel.modules.index = 0;
 						}
-						/// User input mode. 
+						// User input mode. 
 						Key::Char('\n')
 						| Key::Char('s')
 						| Key::Char('S')
@@ -418,11 +418,11 @@ where
 								}
 							}
 						}
-						/// Other character input. 
+						// Other character input. 
 						Key::Char(v) => {
-							/// Check if input is a number except zero. 
+							// Check if input is a number except zero. 
 							let index = v.to_digit(10).unwrap_or(0);
-							/// Show the used module info at given index. 
+							// Show the used module info at given index. 
 							if index != 0 && !kernel.modules.list.is_empty() {
 								app.selected_block = Block::ModuleTable;
 								kernel.modules.show_used_module(index as usize - 1);
@@ -431,13 +431,13 @@ where
 						_ => {}
 					}
 				} else {
-					/// User input mode. 
+					// User input mode. 
 					match input {
-						/// Quit with ctrl-d. 
+						// Quit with ctrl-d. 
 						Key::Ctrl('d') => {
 							break;
 						}
-						/// Switch to the previous input mode. 
+						// Switch to the previous input mode. 
 						Key::Up => {
 							app.input_mode = match app.input_mode.previous() {
 								Some(v) => v,
@@ -448,7 +448,7 @@ where
 							}
 							app.input_query = String::new();
 						}
-						/// Switch to the next input mode. 
+						// Switch to the next input mode. 
 						Key::Down => {
 							app.input_mode = match app.input_mode.next() {
 								Some(v) => v,
@@ -458,24 +458,24 @@ where
 							};
 							app.input_query = String::new();
 						}
-						/// Copy input query to the clipboard. 
+						// Copy input query to the clipboard. 
 						Key::Ctrl('c') => {
 							let query = app.input_query.clone();
 							app.set_clipboard_contents(&query);
 						}
-						/// Paste the clipboard contents. 
+						// Paste the clipboard contents. 
 						Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 						}
-						/// Exit user input mode. 
+						// Exit user input mode. 
 						Key::Char('\n')
 						| Key::Char('\t')
 						| Key::Char('?')
 						| Key::F(1)
 						| Key::Right
 						| Key::Left => {
-							/// Select the next eligible block for action. 
+							// Select the next eligible block for action. 
 							app.selected_block = match input {
 								Key::Left => match app.selected_block.previous() {
 									Some(v) => v,
@@ -496,12 +496,12 @@ where
 								}
 								_ => Block::ModuleTable,
 							};
-							/// Show the first modules information if the search mode is set. 
+							// Show the first modules information if the search mode is set. 
 							if app.input_mode == InputMode::Search
 								&& kernel.modules.index == 0
 							{
 								kernel.modules.scroll_list(ScrollDirection::Top);
-							/// Load kernel module. 
+							// Load kernel module. 
 							} else if app.input_mode == InputMode::Load
 								&& !app.input_query.is_empty()
 							{
@@ -511,25 +511,25 @@ where
 								);
 								app.input_query = String::new();
 							}
-							/// Set the input mode flag. 
+							// Set the input mode flag. 
 							app.input_mode = InputMode::None;
 						}
-						/// Append character to input query. 
+						// Append character to input query. 
 						Key::Char(c) => {
 							app.input_query.push(c);
 							kernel.modules.index = 0;
 						}
-						/// Delete the last character from input query. 
+						// Delete the last character from input query. 
 						Key::Backspace | Key::Ctrl('h') => {
 							app.input_query.pop();
 							kernel.modules.index = 0;
 						}
-						/// Clear the input query. 
+						// Clear the input query. 
 						Key::Delete | Key::Ctrl('l') => {
 							app.input_query = String::new();
 							kernel.modules.index = 0;
 						}
-						/// Clear the input query and exit user input mode. 
+						// Clear the input query and exit user input mode. 
 						Key::Esc => {
 							events.tx.send(Event::Input(Key::Delete)).unwrap();
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
@@ -541,7 +541,7 @@ where
 					app.show_options = false;
 				}
 			}
-			/// Kernel events. 
+			// Kernel events. 
 			Event::Kernel(logs) => {
 				kernel.logs.output = logs;
 			}
@@ -566,7 +566,7 @@ mod tests {
 		let events = Events::new(100, &kernel.logs);
 		let tx = events.tx.clone();
 		thread::spawn(move || {
-			/// Test the general keys. 
+			// Test the general keys. 
 			for key in [
 				Key::Char('?'),
 				Key::Ctrl('t'),
@@ -597,7 +597,7 @@ mod tests {
 				send_key(&tx, key);
 			}
 			send_key(&tx, Key::Char('r'));
-			/// Test the switch keys. 
+			// Test the switch keys. 
 			for arrow_key in [Key::Right, Key::Left] {
 				for selected_key in [arrow_key; Block::CARDINALITY] {
 					send_key(&tx, selected_key);
@@ -614,7 +614,7 @@ mod tests {
 					}
 				}
 			}
-			/// Test the input mode keys. 
+			// Test the input mode keys. 
 			for key in [
 				Key::Char('v'),
 				Key::Delete,
@@ -634,13 +634,13 @@ mod tests {
 			] {
 				send_key(&tx, key);
 			}
-			/// Exit. 
+			// Exit. 
 			send_key(&tx, Key::Esc)
 		});
 		start_tui(Terminal::new(TestBackend::new(20, 10))?, kernel, &events)
 	}
 	
-	/// Try to send a key event until Sender succeeds.
+	// Try to send a key event until Sender succeeds.
 	fn send_key(tx: &Sender<Event<Key>>, key: Key) {
 		let mut x = true;
 		while x {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,7 @@ use unicode_width::UnicodeWidthStr;
 
 /// Configure the terminal and draw its widgets.
  
-/// @param  Terminal
-/// @param  Kernel
-/// @param  Events
-/// @return Result
+
  
 pub fn start_tui<B>(
 	mut terminal: Terminal<B>,
@@ -572,7 +569,7 @@ mod tests {
 		let events = Events::new(100, &kernel.logs);
 		let tx = events.tx.clone();
 		thread::spawn(move || {
-			/* Test the general keys. */
+			/// Test the general keys. 
 			for key in [
 				Key::Char('?'),
 				Key::Ctrl('t'),
@@ -648,8 +645,7 @@ mod tests {
 	
 	/// Try to send a key event until Sender succeeds.
 	 
-	/// @param Sender
-	/// @param Key
+
 	
 	fn send_key(tx: &Sender<Event<Key>>, key: Key) {
 		let mut x = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use std::error::Error;
 use termion::event::Key;
 use unicode_width::UnicodeWidthStr;
 
-
 /// Configure the terminal and draw its widgets.
 pub fn start_tui<B>(
 	mut terminal: Terminal<B>,
@@ -33,7 +32,7 @@ where
 {
 	// Configure the application.
 	let mut app = App::new(Block::ModuleTable, kernel.modules.style.clone());
-	// Draw terminal and render the widgets. 
+	// Draw terminal and render the widgets.
 	loop {
 		terminal.draw(|frame| {
 			let chunks = Layout::default()
@@ -98,15 +97,15 @@ where
 				frame.set_cursor(1 + app.input_query.width() as u16, 1);
 			}
 		})?;
-		// Handle terminal events. 
+		// Handle terminal events.
 		match events.rx.recv()? {
-			// Key input events. 
+			// Key input events.
 			Event::Input(input) => {
 				let mut hide_options = true;
 				if app.input_mode.is_none() {
-					// Default input mode. 
+					// Default input mode.
 					match input {
-						// Quit. 
+						// Quit.
 						Key::Char('q')
 						| Key::Char('Q')
 						| Key::Ctrl('c')
@@ -118,12 +117,12 @@ where
 								break;
 							}
 						}
-						// Refresh. 
+						// Refresh.
 						Key::Char('r') | Key::Char('R') | Key::F(5) => {
 							app.refresh();
 							kernel.refresh();
 						}
-						// Show help message. 
+						// Show help message.
 						Key::Char('?') | Key::F(1) => {
 							app.show_help_message(&mut kernel.modules);
 						}
@@ -131,7 +130,7 @@ where
 							app.show_options = true;
 							hide_options = false;
 						}
-						// Scroll the selected block up. 
+						// Scroll the selected block up.
 						Key::Up
 						| Key::Char('k')
 						| Key::Char('K')
@@ -161,7 +160,7 @@ where
 								_ => {}
 							}
 						}
-						// Scroll the selected block down. 
+						// Scroll the selected block down.
 						Key::Down
 						| Key::Char('j')
 						| Key::Char('J')
@@ -191,7 +190,7 @@ where
 								_ => {}
 							}
 						}
-						// Select the next terminal block. 
+						// Select the next terminal block.
 						Key::Left | Key::Char('h') | Key::Char('H') => {
 							app.selected_block = match app.selected_block.previous()
 							{
@@ -199,14 +198,14 @@ where
 								None => Block::last().unwrap(),
 							}
 						}
-						// Select the previous terminal block. 
+						// Select the previous terminal block.
 						Key::Right | Key::Char('l') | Key::Char('L') => {
 							app.selected_block = match app.selected_block.next() {
 								Some(v) => v,
 								None => Block::first().unwrap(),
 							}
 						}
-						// Expand the selected block. 
+						// Expand the selected block.
 						Key::Alt('e') => {
 							let block_size = app.block_size();
 							if *block_size < 95 {
@@ -215,13 +214,13 @@ where
 								*block_size = 100;
 							}
 						}
-						// Shrink the selected block. 
+						// Shrink the selected block.
 						Key::Alt('s') => {
 							let block_size = app.block_size();
 							*block_size =
 								(*block_size).checked_sub(5).unwrap_or_default()
 						}
-						// Change the block position. 
+						// Change the block position.
 						Key::Ctrl('x') => {
 							if app.block_index == 2 {
 								app.block_index = 0;
@@ -229,24 +228,24 @@ where
 								app.block_index += 1;
 							}
 						}
-						// Scroll to the top of the module list. 
+						// Scroll to the top of the module list.
 						Key::Ctrl('t') | Key::Home => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Top)
 						}
-						// Scroll to the bottom of the module list. 
+						// Scroll to the bottom of the module list.
 						Key::Ctrl('b') | Key::End => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Bottom)
 						}
-						// Scroll kernel activities up. 
+						// Scroll kernel activities up.
 						Key::PageUp => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Up, false);
 						}
-						// Scroll kernel activities down. 
+						// Scroll kernel activities down.
 						Key::PageDown => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Down, false);
@@ -256,34 +255,34 @@ where
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Left, false);
 						}
-						// Scroll kernel activities right. 
+						// Scroll kernel activities right.
 						Key::Alt('l') | Key::Alt('L') => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Right, false);
 						}
-						// Scroll module information up. 
+						// Scroll module information up.
 						Key::Char('<') | Key::Alt(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Up, false)
 						}
-						// Scroll module information down. 
+						// Scroll module information down.
 						Key::Char('>') | Key::Char(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Down, false)
 						}
-						// Show the next kernel information. 
+						// Show the next kernel information.
 						Key::Char('\\') | Key::Char('\t') | Key::BackTab => {
 							kernel.info.next();
 						}
-						// Display the dependent modules. 
+						// Display the dependent modules.
 						Key::Char('d') | Key::Alt('d') => {
 							app.show_dependent_modules(&mut kernel.modules);
 						}
-						// Clear the kernel ring buffer. 
+						// Clear the kernel ring buffer.
 						Key::Ctrl('l')
 						| Key::Ctrl('u')
 						| Key::Alt('c')
@@ -293,7 +292,7 @@ where
 								String::new(),
 							);
 						}
-						// Unload kernel module. 
+						// Unload kernel module.
 						Key::Char('u')
 						| Key::Char('U')
 						| Key::Char('-')
@@ -304,7 +303,7 @@ where
 								String::new(),
 							);
 						}
-						// Blacklist kernel module. 
+						// Blacklist kernel module.
 						Key::Char('x')
 						| Key::Char('X')
 						| Key::Char('b')
@@ -315,7 +314,7 @@ where
 								String::new(),
 							);
 						}
-						// Reload kernel module. 
+						// Reload kernel module.
 						Key::Ctrl('r')
 						| Key::Ctrl('R')
 						| Key::Alt('r')
@@ -325,7 +324,7 @@ where
 								String::new(),
 							);
 						}
-						// Execute the current command. 
+						// Execute the current command.
 						Key::Char('y') | Key::Char('Y') => {
 							if kernel.modules.execute_command() {
 								events
@@ -334,13 +333,13 @@ where
 									.unwrap();
 							}
 						}
-						// Cancel the execution of current command. 
+						// Cancel the execution of current command.
 						Key::Char('n') | Key::Char('N') => {
 							if kernel.modules.cancel_execution() {
 								app.selected_block = Block::ModuleTable;
 							}
 						}
-						// Copy the data in selected block to clipboard. 
+						// Copy the data in selected block to clipboard.
 						Key::Char('c') | Key::Char('C') => {
 							app.set_clipboard_contents(match app.selected_block {
 								Block::ModuleTable => &kernel.modules.current_name,
@@ -353,14 +352,14 @@ where
 								_ => "",
 							});
 						}
-						// Paste the clipboard contents and switch to search mode. 
+						// Paste the clipboard contents and switch to search mode.
 						Key::Char('v') | Key::Ctrl('V') | Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
 							kernel.modules.index = 0;
 						}
-						// User input mode. 
+						// User input mode.
 						Key::Char('\n')
 						| Key::Char('s')
 						| Key::Char('S')
@@ -418,11 +417,11 @@ where
 								}
 							}
 						}
-						// Other character input. 
+						// Other character input.
 						Key::Char(v) => {
-							// Check if input is a number except zero. 
+							// Check if input is a number except zero.
 							let index = v.to_digit(10).unwrap_or(0);
-							// Show the used module info at given index. 
+							// Show the used module info at given index.
 							if index != 0 && !kernel.modules.list.is_empty() {
 								app.selected_block = Block::ModuleTable;
 								kernel.modules.show_used_module(index as usize - 1);
@@ -431,13 +430,13 @@ where
 						_ => {}
 					}
 				} else {
-					// User input mode. 
+					// User input mode.
 					match input {
-						// Quit with ctrl-d. 
+						// Quit with ctrl-d.
 						Key::Ctrl('d') => {
 							break;
 						}
-						// Switch to the previous input mode. 
+						// Switch to the previous input mode.
 						Key::Up => {
 							app.input_mode = match app.input_mode.previous() {
 								Some(v) => v,
@@ -448,7 +447,7 @@ where
 							}
 							app.input_query = String::new();
 						}
-						// Switch to the next input mode. 
+						// Switch to the next input mode.
 						Key::Down => {
 							app.input_mode = match app.input_mode.next() {
 								Some(v) => v,
@@ -458,24 +457,24 @@ where
 							};
 							app.input_query = String::new();
 						}
-						// Copy input query to the clipboard. 
+						// Copy input query to the clipboard.
 						Key::Ctrl('c') => {
 							let query = app.input_query.clone();
 							app.set_clipboard_contents(&query);
 						}
-						// Paste the clipboard contents. 
+						// Paste the clipboard contents.
 						Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 						}
-						// Exit user input mode. 
+						// Exit user input mode.
 						Key::Char('\n')
 						| Key::Char('\t')
 						| Key::Char('?')
 						| Key::F(1)
 						| Key::Right
 						| Key::Left => {
-							// Select the next eligible block for action. 
+							// Select the next eligible block for action.
 							app.selected_block = match input {
 								Key::Left => match app.selected_block.previous() {
 									Some(v) => v,
@@ -496,12 +495,12 @@ where
 								}
 								_ => Block::ModuleTable,
 							};
-							// Show the first modules information if the search mode is set. 
+							// Show the first modules information if the search mode is set.
 							if app.input_mode == InputMode::Search
 								&& kernel.modules.index == 0
 							{
 								kernel.modules.scroll_list(ScrollDirection::Top);
-							// Load kernel module. 
+							// Load kernel module.
 							} else if app.input_mode == InputMode::Load
 								&& !app.input_query.is_empty()
 							{
@@ -511,25 +510,25 @@ where
 								);
 								app.input_query = String::new();
 							}
-							// Set the input mode flag. 
+							// Set the input mode flag.
 							app.input_mode = InputMode::None;
 						}
-						// Append character to input query. 
+						// Append character to input query.
 						Key::Char(c) => {
 							app.input_query.push(c);
 							kernel.modules.index = 0;
 						}
-						// Delete the last character from input query. 
+						// Delete the last character from input query.
 						Key::Backspace | Key::Ctrl('h') => {
 							app.input_query.pop();
 							kernel.modules.index = 0;
 						}
-						// Clear the input query. 
+						// Clear the input query.
 						Key::Delete | Key::Ctrl('l') => {
 							app.input_query = String::new();
 							kernel.modules.index = 0;
 						}
-						// Clear the input query and exit user input mode. 
+						// Clear the input query and exit user input mode.
 						Key::Esc => {
 							events.tx.send(Event::Input(Key::Delete)).unwrap();
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
@@ -541,7 +540,7 @@ where
 					app.show_options = false;
 				}
 			}
-			// Kernel events. 
+			// Kernel events.
 			Event::Kernel(logs) => {
 				kernel.logs.output = logs;
 			}
@@ -566,7 +565,7 @@ mod tests {
 		let events = Events::new(100, &kernel.logs);
 		let tx = events.tx.clone();
 		thread::spawn(move || {
-			// Test the general keys. 
+			// Test the general keys.
 			for key in [
 				Key::Char('?'),
 				Key::Ctrl('t'),
@@ -597,7 +596,7 @@ mod tests {
 				send_key(&tx, key);
 			}
 			send_key(&tx, Key::Char('r'));
-			// Test the switch keys. 
+			// Test the switch keys.
 			for arrow_key in [Key::Right, Key::Left] {
 				for selected_key in [arrow_key; Block::CARDINALITY] {
 					send_key(&tx, selected_key);
@@ -614,7 +613,7 @@ mod tests {
 					}
 				}
 			}
-			// Test the input mode keys. 
+			// Test the input mode keys.
 			for key in [
 				Key::Char('v'),
 				Key::Delete,
@@ -634,12 +633,12 @@ mod tests {
 			] {
 				send_key(&tx, key);
 			}
-			// Exit. 
+			// Exit.
 			send_key(&tx, Key::Esc)
 		});
 		start_tui(Terminal::new(TestBackend::new(20, 10))?, kernel, &events)
 	}
-	
+
 	// Try to send a key event until Sender succeeds.
 	fn send_key(tx: &Sender<Event<Key>>, key: Key) {
 		let mut x = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,14 @@ use std::error::Error;
 use termion::event::Key;
 use unicode_width::UnicodeWidthStr;
 
-/**
- * Configure the terminal and draw its widgets.
- *
- * @param  Terminal
- * @param  Kernel
- * @param  Events
- * @return Result
- */
+
+/// Configure the terminal and draw its widgets.
+ 
+/// @param  Terminal
+/// @param  Kernel
+/// @param  Events
+/// @return Result
+ 
 pub fn start_tui<B>(
 	mut terminal: Terminal<B>,
 	mut kernel: Kernel,
@@ -37,9 +37,9 @@ pub fn start_tui<B>(
 where
 	B: Backend,
 {
-	/* Configure the application. */
+	/// Configure the application.
 	let mut app = App::new(Block::ModuleTable, kernel.modules.style.clone());
-	/* Draw terminal and render the widgets. */
+	/// Draw terminal and render the widgets. 
 	loop {
 		terminal.draw(|frame| {
 			let chunks = Layout::default()
@@ -104,15 +104,15 @@ where
 				frame.set_cursor(1 + app.input_query.width() as u16, 1);
 			}
 		})?;
-		/* Handle terminal events. */
+		/// Handle terminal events. 
 		match events.rx.recv()? {
-			/* Key input events. */
+			/// Key input events. 
 			Event::Input(input) => {
 				let mut hide_options = true;
 				if app.input_mode.is_none() {
-					/* Default input mode. */
+					/// Default input mode. 
 					match input {
-						/* Quit. */
+						/// Quit. 
 						Key::Char('q')
 						| Key::Char('Q')
 						| Key::Ctrl('c')
@@ -124,12 +124,12 @@ where
 								break;
 							}
 						}
-						/* Refresh. */
+						/// Refresh. 
 						Key::Char('r') | Key::Char('R') | Key::F(5) => {
 							app.refresh();
 							kernel.refresh();
 						}
-						/* Show help message. */
+						/// Show help message. 
 						Key::Char('?') | Key::F(1) => {
 							app.show_help_message(&mut kernel.modules);
 						}
@@ -137,7 +137,7 @@ where
 							app.show_options = true;
 							hide_options = false;
 						}
-						/* Scroll the selected block up. */
+						/// Scroll the selected block up. 
 						Key::Up
 						| Key::Char('k')
 						| Key::Char('K')
@@ -167,7 +167,7 @@ where
 								_ => {}
 							}
 						}
-						/* Scroll the selected block down. */
+						/// Scroll the selected block down. 
 						Key::Down
 						| Key::Char('j')
 						| Key::Char('J')
@@ -197,7 +197,7 @@ where
 								_ => {}
 							}
 						}
-						/* Select the next terminal block. */
+						/// Select the next terminal block. 
 						Key::Left | Key::Char('h') | Key::Char('H') => {
 							app.selected_block = match app.selected_block.previous()
 							{
@@ -205,14 +205,14 @@ where
 								None => Block::last().unwrap(),
 							}
 						}
-						/* Select the previous terminal block. */
+						/// Select the previous terminal block. 
 						Key::Right | Key::Char('l') | Key::Char('L') => {
 							app.selected_block = match app.selected_block.next() {
 								Some(v) => v,
 								None => Block::first().unwrap(),
 							}
 						}
-						/* Expand the selected block. */
+						/// Expand the selected block. 
 						Key::Alt('e') => {
 							let block_size = app.block_size();
 							if *block_size < 95 {
@@ -221,13 +221,13 @@ where
 								*block_size = 100;
 							}
 						}
-						/* Shrink the selected block. */
+						/// Shrink the selected block. 
 						Key::Alt('s') => {
 							let block_size = app.block_size();
 							*block_size =
 								(*block_size).checked_sub(5).unwrap_or_default()
 						}
-						/* Change the block position. */
+						/// Change the block position. 
 						Key::Ctrl('x') => {
 							if app.block_index == 2 {
 								app.block_index = 0;
@@ -235,61 +235,61 @@ where
 								app.block_index += 1;
 							}
 						}
-						/* Scroll to the top of the module list. */
+						/// Scroll to the top of the module list. 
 						Key::Ctrl('t') | Key::Home => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Top)
 						}
-						/* Scroll to the bottom of the module list. */
+						/// Scroll to the bottom of the module list. 
 						Key::Ctrl('b') | Key::End => {
 							app.options.state.select(Some(0));
 							app.selected_block = Block::ModuleTable;
 							kernel.modules.scroll_list(ScrollDirection::Bottom)
 						}
-						/* Scroll kernel activities up. */
+						/// Scroll kernel activities up. 
 						Key::PageUp => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Up, false);
 						}
-						/* Scroll kernel activities down. */
+						/// Scroll kernel activities down. 
 						Key::PageDown => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Down, false);
 						}
-						/* Scroll kernel activities left. */
+						/// Scroll kernel activities left.
 						Key::Alt('h') | Key::Alt('H') => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Left, false);
 						}
-						/* Scroll kernel activities right. */
+						/// Scroll kernel activities right. 
 						Key::Alt('l') | Key::Alt('L') => {
 							app.selected_block = Block::Activities;
 							kernel.logs.scroll(ScrollDirection::Right, false);
 						}
-						/* Scroll module information up. */
+						/// Scroll module information up. 
 						Key::Char('<') | Key::Alt(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Up, false)
 						}
-						/* Scroll module information down. */
+						/// Scroll module information down. 
 						Key::Char('>') | Key::Char(' ') => {
 							app.selected_block = Block::ModuleInfo;
 							kernel
 								.modules
 								.scroll_mod_info(ScrollDirection::Down, false)
 						}
-						/* Show the next kernel information. */
+						/// Show the next kernel information. 
 						Key::Char('\\') | Key::Char('\t') | Key::BackTab => {
 							kernel.info.next();
 						}
-						/* Display the dependent modules. */
+						/// Display the dependent modules. 
 						Key::Char('d') | Key::Alt('d') => {
 							app.show_dependent_modules(&mut kernel.modules);
 						}
-						/* Clear the kernel ring buffer. */
+						/// Clear the kernel ring buffer. 
 						Key::Ctrl('l')
 						| Key::Ctrl('u')
 						| Key::Alt('c')
@@ -299,7 +299,7 @@ where
 								String::new(),
 							);
 						}
-						/* Unload kernel module. */
+						/// Unload kernel module. 
 						Key::Char('u')
 						| Key::Char('U')
 						| Key::Char('-')
@@ -310,7 +310,7 @@ where
 								String::new(),
 							);
 						}
-						/* Blacklist kernel module. */
+						/// Blacklist kernel module. 
 						Key::Char('x')
 						| Key::Char('X')
 						| Key::Char('b')
@@ -321,7 +321,7 @@ where
 								String::new(),
 							);
 						}
-						/* Reload kernel module. */
+						/// Reload kernel module. 
 						Key::Ctrl('r')
 						| Key::Ctrl('R')
 						| Key::Alt('r')
@@ -331,7 +331,7 @@ where
 								String::new(),
 							);
 						}
-						/* Execute the current command. */
+						/// Execute the current command. 
 						Key::Char('y') | Key::Char('Y') => {
 							if kernel.modules.execute_command() {
 								events
@@ -340,13 +340,13 @@ where
 									.unwrap();
 							}
 						}
-						/* Cancel the execution of current command. */
+						/// Cancel the execution of current command. 
 						Key::Char('n') | Key::Char('N') => {
 							if kernel.modules.cancel_execution() {
 								app.selected_block = Block::ModuleTable;
 							}
 						}
-						/* Copy the data in selected block to clipboard. */
+						/// Copy the data in selected block to clipboard. 
 						Key::Char('c') | Key::Char('C') => {
 							app.set_clipboard_contents(match app.selected_block {
 								Block::ModuleTable => &kernel.modules.current_name,
@@ -359,14 +359,14 @@ where
 								_ => "",
 							});
 						}
-						/* Paste the clipboard contents and switch to search mode. */
+						/// Paste the clipboard contents and switch to search mode. 
 						Key::Char('v') | Key::Ctrl('V') | Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
 							kernel.modules.index = 0;
 						}
-						/* User input mode. */
+						/// User input mode. 
 						Key::Char('\n')
 						| Key::Char('s')
 						| Key::Char('S')
@@ -424,11 +424,11 @@ where
 								}
 							}
 						}
-						/* Other character input. */
+						/// Other character input. 
 						Key::Char(v) => {
-							/* Check if input is a number except zero. */
+							/// Check if input is a number except zero. 
 							let index = v.to_digit(10).unwrap_or(0);
-							/* Show the used module info at given index. */
+							/// Show the used module info at given index. 
 							if index != 0 && !kernel.modules.list.is_empty() {
 								app.selected_block = Block::ModuleTable;
 								kernel.modules.show_used_module(index as usize - 1);
@@ -437,13 +437,13 @@ where
 						_ => {}
 					}
 				} else {
-					/* User input mode. */
+					/// User input mode. 
 					match input {
-						/* Quit with ctrl-d. */
+						/// Quit with ctrl-d. 
 						Key::Ctrl('d') => {
 							break;
 						}
-						/* Switch to the previous input mode. */
+						/// Switch to the previous input mode. 
 						Key::Up => {
 							app.input_mode = match app.input_mode.previous() {
 								Some(v) => v,
@@ -454,7 +454,7 @@ where
 							}
 							app.input_query = String::new();
 						}
-						/* Switch to the next input mode. */
+						/// Switch to the next input mode. 
 						Key::Down => {
 							app.input_mode = match app.input_mode.next() {
 								Some(v) => v,
@@ -464,24 +464,24 @@ where
 							};
 							app.input_query = String::new();
 						}
-						/* Copy input query to the clipboard. */
+						/// Copy input query to the clipboard. 
 						Key::Ctrl('c') => {
 							let query = app.input_query.clone();
 							app.set_clipboard_contents(&query);
 						}
-						/* Paste the clipboard contents. */
+						/// Paste the clipboard contents. 
 						Key::Ctrl('v') => {
 							let clipboard_contents = app.get_clipboard_contents();
 							app.input_query += &clipboard_contents;
 						}
-						/* Exit user input mode. */
+						/// Exit user input mode. 
 						Key::Char('\n')
 						| Key::Char('\t')
 						| Key::Char('?')
 						| Key::F(1)
 						| Key::Right
 						| Key::Left => {
-							/* Select the next eligible block for action. */
+							/// Select the next eligible block for action. 
 							app.selected_block = match input {
 								Key::Left => match app.selected_block.previous() {
 									Some(v) => v,
@@ -502,12 +502,12 @@ where
 								}
 								_ => Block::ModuleTable,
 							};
-							/* Show the first modules information if the search mode is set. */
+							/// Show the first modules information if the search mode is set. 
 							if app.input_mode == InputMode::Search
 								&& kernel.modules.index == 0
 							{
 								kernel.modules.scroll_list(ScrollDirection::Top);
-							/* Load kernel module. */
+							/// Load kernel module. 
 							} else if app.input_mode == InputMode::Load
 								&& !app.input_query.is_empty()
 							{
@@ -517,25 +517,25 @@ where
 								);
 								app.input_query = String::new();
 							}
-							/* Set the input mode flag. */
+							/// Set the input mode flag. 
 							app.input_mode = InputMode::None;
 						}
-						/* Append character to input query. */
+						/// Append character to input query. 
 						Key::Char(c) => {
 							app.input_query.push(c);
 							kernel.modules.index = 0;
 						}
-						/* Delete the last character from input query. */
+						/// Delete the last character from input query. 
 						Key::Backspace | Key::Ctrl('h') => {
 							app.input_query.pop();
 							kernel.modules.index = 0;
 						}
-						/* Clear the input query. */
+						/// Clear the input query. 
 						Key::Delete | Key::Ctrl('l') => {
 							app.input_query = String::new();
 							kernel.modules.index = 0;
 						}
-						/* Clear the input query and exit user input mode. */
+						/// Clear the input query and exit user input mode. 
 						Key::Esc => {
 							events.tx.send(Event::Input(Key::Delete)).unwrap();
 							events.tx.send(Event::Input(Key::Char('\n'))).unwrap();
@@ -547,7 +547,7 @@ where
 					app.show_options = false;
 				}
 			}
-			/* Kernel events. */
+			/// Kernel events. 
 			Event::Kernel(logs) => {
 				kernel.logs.output = logs;
 			}
@@ -603,7 +603,7 @@ mod tests {
 				send_key(&tx, key);
 			}
 			send_key(&tx, Key::Char('r'));
-			/* Test the switch keys. */
+			/// Test the switch keys. 
 			for arrow_key in [Key::Right, Key::Left] {
 				for selected_key in [arrow_key; Block::CARDINALITY] {
 					send_key(&tx, selected_key);
@@ -620,7 +620,7 @@ mod tests {
 					}
 				}
 			}
-			/* Test the input mode keys. */
+			/// Test the input mode keys. 
 			for key in [
 				Key::Char('v'),
 				Key::Delete,
@@ -640,17 +640,17 @@ mod tests {
 			] {
 				send_key(&tx, key);
 			}
-			/* Exit. */
+			/// Exit. 
 			send_key(&tx, Key::Esc)
 		});
 		start_tui(Terminal::new(TestBackend::new(20, 10))?, kernel, &events)
 	}
-	/**
-	 * Try to send a key event until Sender succeeds.
-	 *
-	 * @param Sender
-	 * @param Key
-	 */
+	
+	/// Try to send a key event until Sender succeeds.
+	 
+	/// @param Sender
+	/// @param Key
+	
 	fn send_key(tx: &Sender<Event<Key>>, key: Key) {
 		let mut x = true;
 		while x {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use termion::screen::IntoAlternateScreen;
 
 /// Entry point.
  
-/// @return Result
+
  
 fn main() -> Result<(), Box<dyn Error>> {
 	let args = args::get_args().get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
 
-/**
- * Entry point.
- *
- * @return Result
- */
+
+/// Entry point.
+ 
+/// @return Result
+ 
 fn main() -> Result<(), Box<dyn Error>> {
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@ use termion::screen::IntoAlternateScreen;
 
 
 /// Entry point.
- 
-
- 
 fn main() -> Result<(), Box<dyn Error>> {
 	let args = args::get_args().get_matches();
 	let kernel = Kernel::new(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
 
-
 /// Entry point.
 fn main() -> Result<(), Box<dyn Error>> {
 	let args = args::get_args().get_matches();

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style as TuiStyle};
 use ratatui::text::{Line, Span, Text};
 use std::collections::HashMap;
 
-/// Unicode symbol 
+/// Unicode symbol
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Symbol {
 	None,
@@ -24,7 +24,7 @@ pub enum Symbol {
 	HistoricSite,
 }
 
-/// Supported Unicode symbols 
+/// Supported Unicode symbols
 #[derive(Clone, Debug)]
 pub struct Unicode<'a> {
 	symbols: HashMap<Symbol, &'a [&'a str; 2]>,
@@ -32,7 +32,6 @@ pub struct Unicode<'a> {
 }
 
 impl Unicode<'_> {
-	
 	/// Create a new Unicode instance.
 	pub fn new(replace: bool) -> Self {
 		Self {
@@ -56,14 +55,14 @@ impl Unicode<'_> {
 			replace,
 		}
 	}
-	
+
 	/// Get string from a Unicode symbol.
 	pub fn get(&self, symbol: Symbol) -> &str {
 		self.symbols[&symbol][self.replace as usize]
 	}
 }
 
-/// Style properties 
+/// Style properties
 #[derive(Clone, Debug)]
 pub struct Style {
 	pub default: TuiStyle,
@@ -73,7 +72,6 @@ pub struct Style {
 }
 
 impl Style {
-	
 	/// Create a new style instance from given arguments.
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut default = TuiStyle::reset();
@@ -95,7 +93,6 @@ impl Style {
 		}
 	}
 
-	
 	/// Parse a color value from arguments.
 	fn get_color(args: &ArgMatches, arg_name: &str, default_color: Color) -> Color {
 		let colors = map![
@@ -133,7 +130,7 @@ impl Style {
 	}
 }
 
-/// Styled text that has raw and style parts 
+/// Styled text that has raw and style parts
 #[derive(Debug, Default)]
 pub struct StyledText<'a> {
 	pub raw_text: String,
@@ -141,7 +138,6 @@ pub struct StyledText<'a> {
 }
 
 impl<'a> StyledText<'a> {
-	
 	/// Get a vector of Text widget from styled text.
 	pub fn get(&'a self) -> Text<'a> {
 		if self.styled_text.lines.is_empty() {
@@ -151,14 +147,12 @@ impl<'a> StyledText<'a> {
 		}
 	}
 
-	
 	/// Set a styled text.
 	pub fn set(&mut self, text: Text<'static>, placeholder: String) {
 		self.styled_text = text;
 		self.raw_text = placeholder;
 	}
 
-	
 	/// Add style to given text depending on a delimiter.
 	pub fn stylize_data(
 		&mut self,
@@ -184,7 +178,6 @@ impl<'a> StyledText<'a> {
 		self.styled_text.clone()
 	}
 
-	
 	/// Return the line count of styled text.
 	pub fn lines(&self) -> usize {
 		if self.styled_text.lines.is_empty() {

--- a/src/style.rs
+++ b/src/style.rs
@@ -35,8 +35,7 @@ impl Unicode<'_> {
 	
 	/// Create a new Unicode instance.
 	 
-	/// @param  replace
-	/// @return Unicode
+	
 	 
 	pub fn new(replace: bool) -> Self {
 		Self {
@@ -62,9 +61,7 @@ impl Unicode<'_> {
 	}
 	
 	/// Get string from a Unicode symbol.
-	 
-	/// @param  Symbol
-	/// @return str
+	
 	
 	pub fn get(&self, symbol: Symbol) -> &str {
 		self.symbols[&symbol][self.replace as usize]
@@ -84,8 +81,7 @@ impl Style {
 	
 	/// Create a new style instance from given arguments.
 	 
-	/// @param  args
-	/// @return Style
+	
 	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut default = TuiStyle::reset();
@@ -110,10 +106,7 @@ impl Style {
 	
 	/// Parse a color value from arguments.
 	 
-	/// @param  args
-	/// @param  arg_name
-	/// @param  default_color
-	/// @return Color
+	
 	 
 	fn get_color(args: &ArgMatches, arg_name: &str, default_color: Color) -> Color {
 		let colors = map![
@@ -162,7 +155,7 @@ impl<'a> StyledText<'a> {
 	
 	/// Get a vector of Text widget from styled text.
 	 
-	/// @return vector
+	
 	
 	pub fn get(&'a self) -> Text<'a> {
 		if self.styled_text.lines.is_empty() {
@@ -175,8 +168,7 @@ impl<'a> StyledText<'a> {
 	
 	/// Set a styled text.
 	 
-	/// @param text
-	/// @param placeholder
+	
 	 
 	pub fn set(&mut self, text: Text<'static>, placeholder: String) {
 		self.styled_text = text;
@@ -186,10 +178,7 @@ impl<'a> StyledText<'a> {
 	
 	/// Add style to given text depending on a delimiter.
 	 
-	/// @param  text
-	/// @param  delimiter
-	/// @param  style
-	/// @return vector
+	
 	
 	pub fn stylize_data(
 		&mut self,
@@ -218,7 +207,7 @@ impl<'a> StyledText<'a> {
 	
 	/// Return the line count of styled text.
 	 
-	/// @return usize
+	
 	
 	pub fn lines(&self) -> usize {
 		if self.styled_text.lines.is_empty() {

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style as TuiStyle};
 use ratatui::text::{Line, Span, Text};
 use std::collections::HashMap;
 
-/* Unicode symbol */
+/// Unicode symbol 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Symbol {
 	None,
@@ -24,7 +24,7 @@ pub enum Symbol {
 	HistoricSite,
 }
 
-/* Supported Unicode symbols */
+/// Supported Unicode symbols 
 #[derive(Clone, Debug)]
 pub struct Unicode<'a> {
 	symbols: HashMap<Symbol, &'a [&'a str; 2]>,
@@ -32,12 +32,12 @@ pub struct Unicode<'a> {
 }
 
 impl Unicode<'_> {
-	/**
-	 * Create a new Unicode instance.
-	 *
-	 * @param  replace
-	 * @return Unicode
-	 */
+	
+	/// Create a new Unicode instance.
+	 
+	/// @param  replace
+	/// @return Unicode
+	 
 	pub fn new(replace: bool) -> Self {
 		Self {
 			symbols: map! {
@@ -60,18 +60,18 @@ impl Unicode<'_> {
 			replace,
 		}
 	}
-	/**
-	 * Get string from a Unicode symbol.
-	 *
-	 * @param  Symbol
-	 * @return str
-	 */
+	
+	/// Get string from a Unicode symbol.
+	 
+	/// @param  Symbol
+	/// @return str
+	
 	pub fn get(&self, symbol: Symbol) -> &str {
 		self.symbols[&symbol][self.replace as usize]
 	}
 }
 
-/* Style properties */
+/// Style properties 
 #[derive(Clone, Debug)]
 pub struct Style {
 	pub default: TuiStyle,
@@ -81,12 +81,12 @@ pub struct Style {
 }
 
 impl Style {
-	/**
-	 * Create a new style instance from given arguments.
-	 *
-	 * @param  args
-	 * @return Style
-	 */
+	
+	/// Create a new style instance from given arguments.
+	 
+	/// @param  args
+	/// @return Style
+	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut default = TuiStyle::reset();
 		if let Ok(true) = args.try_contains_id("accent-color") {
@@ -107,14 +107,14 @@ impl Style {
 		}
 	}
 
-	/**
-	 * Parse a color value from arguments.
-	 *
-	 * @param  args
-	 * @param  arg_name
-	 * @param  default_color
-	 * @return Color
-	 */
+	
+	/// Parse a color value from arguments.
+	 
+	/// @param  args
+	/// @param  arg_name
+	/// @param  default_color
+	/// @return Color
+	 
 	fn get_color(args: &ArgMatches, arg_name: &str, default_color: Color) -> Color {
 		let colors = map![
 			"black" => Color::Black,
@@ -151,7 +151,7 @@ impl Style {
 	}
 }
 
-/* Styled text that has raw and style parts */
+/// Styled text that has raw and style parts 
 #[derive(Debug, Default)]
 pub struct StyledText<'a> {
 	pub raw_text: String,
@@ -159,11 +159,11 @@ pub struct StyledText<'a> {
 }
 
 impl<'a> StyledText<'a> {
-	/**
-	 * Get a vector of Text widget from styled text.
-	 *
-	 * @return vector
-	 */
+	
+	/// Get a vector of Text widget from styled text.
+	 
+	/// @return vector
+	
 	pub fn get(&'a self) -> Text<'a> {
 		if self.styled_text.lines.is_empty() {
 			Text::raw(&self.raw_text)
@@ -172,25 +172,25 @@ impl<'a> StyledText<'a> {
 		}
 	}
 
-	/**
-	 * Set a styled text.
-	 *
-	 * @param text
-	 * @param placeholder
-	 */
+	
+	/// Set a styled text.
+	 
+	/// @param text
+	/// @param placeholder
+	 
 	pub fn set(&mut self, text: Text<'static>, placeholder: String) {
 		self.styled_text = text;
 		self.raw_text = placeholder;
 	}
 
-	/**
-	 * Add style to given text depending on a delimiter.
-	 *
-	 * @param  text
-	 * @param  delimiter
-	 * @param  style
-	 * @return vector
-	 */
+	
+	/// Add style to given text depending on a delimiter.
+	 
+	/// @param  text
+	/// @param  delimiter
+	/// @param  style
+	/// @return vector
+	
 	pub fn stylize_data(
 		&mut self,
 		text: &'a str,
@@ -215,11 +215,11 @@ impl<'a> StyledText<'a> {
 		self.styled_text.clone()
 	}
 
-	/**
-	 * Return the line count of styled text.
-	 *
-	 * @return usize
-	 */
+	
+	/// Return the line count of styled text.
+	 
+	/// @return usize
+	
 	pub fn lines(&self) -> usize {
 		if self.styled_text.lines.is_empty() {
 			self.raw_text.lines().count()

--- a/src/style.rs
+++ b/src/style.rs
@@ -34,9 +34,6 @@ pub struct Unicode<'a> {
 impl Unicode<'_> {
 	
 	/// Create a new Unicode instance.
-	 
-	
-	 
 	pub fn new(replace: bool) -> Self {
 		Self {
 			symbols: map! {
@@ -61,8 +58,6 @@ impl Unicode<'_> {
 	}
 	
 	/// Get string from a Unicode symbol.
-	
-	
 	pub fn get(&self, symbol: Symbol) -> &str {
 		self.symbols[&symbol][self.replace as usize]
 	}
@@ -80,9 +75,6 @@ pub struct Style {
 impl Style {
 	
 	/// Create a new style instance from given arguments.
-	 
-	
-	
 	pub fn new(args: &ArgMatches) -> Self {
 		let mut default = TuiStyle::reset();
 		if let Ok(true) = args.try_contains_id("accent-color") {
@@ -105,9 +97,6 @@ impl Style {
 
 	
 	/// Parse a color value from arguments.
-	 
-	
-	 
 	fn get_color(args: &ArgMatches, arg_name: &str, default_color: Color) -> Color {
 		let colors = map![
 			"black" => Color::Black,
@@ -154,9 +143,6 @@ pub struct StyledText<'a> {
 impl<'a> StyledText<'a> {
 	
 	/// Get a vector of Text widget from styled text.
-	 
-	
-	
 	pub fn get(&'a self) -> Text<'a> {
 		if self.styled_text.lines.is_empty() {
 			Text::raw(&self.raw_text)
@@ -167,9 +153,6 @@ impl<'a> StyledText<'a> {
 
 	
 	/// Set a styled text.
-	 
-	
-	 
 	pub fn set(&mut self, text: Text<'static>, placeholder: String) {
 		self.styled_text = text;
 		self.raw_text = placeholder;
@@ -177,9 +160,6 @@ impl<'a> StyledText<'a> {
 
 	
 	/// Add style to given text depending on a delimiter.
-	 
-	
-	
 	pub fn stylize_data(
 		&mut self,
 		text: &'a str,
@@ -206,9 +186,6 @@ impl<'a> StyledText<'a> {
 
 	
 	/// Return the line count of styled text.
-	 
-	
-	
 	pub fn lines(&self) -> usize {
 		if self.styled_text.lines.is_empty() {
 			self.raw_text.lines().count()

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,10 +42,6 @@ pub const KEY_BINDINGS: &[(&str, &str)] = &[
 
 
 /// Execute a operating system command and return its output.
-
-
-
-
 pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 	match Command::new(cmd).args(cmd_args).output() {
 		Ok(output) => {
@@ -69,9 +65,6 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 /// Sets up the panic hook for the terminal.
 
 /// See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
- 
-
-
 pub fn setup_panic_hook() -> Result<(), Box<dyn Error>> {
 	let raw_output = io::stdout().into_raw_mode()?;
 	raw_output.suspend_raw_mode()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use std::panic;
 use std::process::Command;
 use termion::raw::IntoRawMode;
 
-/* Macro for concise initialization of hashmap */
+/// Macro for concise initialization of hashmap 
 macro_rules! map {
     ($( $key: expr => $val: expr ),*) => {{
          let mut map = ::std::collections::HashMap::new();
@@ -13,7 +13,7 @@ macro_rules! map {
     }}
 }
 
-/* Array of the key bindings */
+/// Array of the key bindings 
 pub const KEY_BINDINGS: &[(&str, &str)] = &[
 	("'?', f1", "help"),
 	("right/left, h/l", "switch between blocks"),
@@ -40,13 +40,14 @@ pub const KEY_BINDINGS: &[(&str, &str)] = &[
 	("q, ctrl-c/d, esc", "quit"),
 ];
 
-/**
- * Execute a operating system command and return its output.
- *
- * @param  cmd
- * @param  cmd_args
- * @return Result
- */
+
+/// Execute a operating system command and return its output.
+
+/// @param  cmd
+/// @param  cmd_args
+/// @return Result
+
+
 pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 	match Command::new(cmd).args(cmd_args).output() {
 		Ok(output) => {
@@ -66,13 +67,13 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 	}
 }
 
-/**
- * Sets up the panic hook for the terminal.
- *
- * See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
- *
- * @return Result
- */
+
+/// Sets up the panic hook for the terminal.
+
+/// See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
+ 
+/// @return Result
+
 pub fn setup_panic_hook() -> Result<(), Box<dyn Error>> {
 	let raw_output = io::stdout().into_raw_mode()?;
 	raw_output.suspend_raw_mode()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,9 +43,7 @@ pub const KEY_BINDINGS: &[(&str, &str)] = &[
 
 /// Execute a operating system command and return its output.
 
-/// @param  cmd
-/// @param  cmd_args
-/// @return Result
+
 
 
 pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
@@ -72,7 +70,7 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 
 /// See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
  
-/// @return Result
+
 
 pub fn setup_panic_hook() -> Result<(), Box<dyn Error>> {
 	let raw_output = io::stdout().into_raw_mode()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use std::panic;
 use std::process::Command;
 use termion::raw::IntoRawMode;
 
-/// Macro for concise initialization of hashmap 
+/// Macro for concise initialization of hashmap
 macro_rules! map {
     ($( $key: expr => $val: expr ),*) => {{
          let mut map = ::std::collections::HashMap::new();
@@ -13,7 +13,7 @@ macro_rules! map {
     }}
 }
 
-/// Array of the key bindings 
+/// Array of the key bindings
 pub const KEY_BINDINGS: &[(&str, &str)] = &[
 	("'?', f1", "help"),
 	("right/left, h/l", "switch between blocks"),
@@ -40,7 +40,6 @@ pub const KEY_BINDINGS: &[(&str, &str)] = &[
 	("q, ctrl-c/d, esc", "quit"),
 ];
 
-
 /// Execute a operating system command and return its output.
 pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 	match Command::new(cmd).args(cmd_args).output() {
@@ -60,7 +59,6 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 		Err(e) => Err(e.to_string()),
 	}
 }
-
 
 /// Sets up the panic hook for the terminal.
 


### PR DESCRIPTION
## Description
Changed the comments syntax from `/* */` to `///` in the codebase.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
