### PR TITLE
chore: replace make with $(MAKE) in example Makefile

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -4,8 +4,8 @@ KERNEL_BUILD=/lib/modules/$(VER)/build
 obj-m += lkm_example.o
 
 all:
-	make -C $(KERNEL_BUILD) M=$(PWD) modules
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules
 install:
-	make -C $(KERNEL_BUILD) M=$(PWD) modules_install
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules_install
 clean:
-	make -C $(KERNEL_BUILD) M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) clean


### PR DESCRIPTION
## Description
- Replace make with $(MAKE) in example Makefile

## Motivation and Context
According to [GNU Make Manual](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html),

Recursive make commands should always use the variable MAKE, not the explicit command name make.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
