### PR TITLE
refactor: replace format! with other macros/methods when unnecessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ fn build_shell_completions(out_dir: &Path) -> Result<(), IoError> {
 fn build_manpage(out_dir: &Path) -> Result<(), IoError> {
 	fs::create_dir_all(out_dir)?;
 	let app = args::get_args();
-	let file = out_dir.join(format!("{}.8", env!("CARGO_PKG_NAME")));
+	let file = out_dir.join(concat!(env!("CARGO_PKG_NAME"), ".8"));
 	let mut file = File::create(file)?;
 	Man::new(app).render(&mut file)?;
 	Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -383,7 +383,7 @@ impl App {
 		for module in &mut kernel_module_list {
 			if module[2].len() > dependent_width {
 				module[2].truncate(dependent_width);
-				module[2] = format!("{}...", module[2]);
+				module[2].push_str("...");
 			}
 		}
 		kernel_modules.list = kernel_module_list;

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,12 +15,15 @@ pub fn get_args() -> App {
 	App::new(env!("CARGO_PKG_NAME"))
 		.version(env!("CARGO_PKG_VERSION"))
 		.author(env!("CARGO_PKG_AUTHORS"))
-		.about(format!(
-			"{} {}\n{}\n{}\n\n{}",
+		.about(concat!(
 			env!("CARGO_PKG_NAME"),
+			" ",
 			env!("CARGO_PKG_VERSION"),
+			"\n",
 			env!("CARGO_PKG_AUTHORS"),
+			"\n",
 			env!("CARGO_PKG_DESCRIPTION"),
+			"\n\n",
 			"Press '?' while running the terminal UI to see key bindings."
 		))
 		.before_help(ASCII_LOGO)

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -109,7 +109,8 @@ impl KernelModules<'_> {
 			let columns: Vec<&str> = line.split_whitespace().collect();
 			let mut module_name = format!(" {}", columns[0]);
 			if columns.len() >= 7 {
-				module_name = format!("{} {}", module_name, columns[6]);
+				module_name.push(' ');
+				module_name.push_str(columns[6]);
 			}
 			let mut used_modules = format!("{} {}", columns[2], columns[3]);
 			if used_modules.ends_with(',') {


### PR DESCRIPTION
## Description
- Replace `format!` macro with other macros/methods (such as `concat!`) when it is unnecessary

## Motivation and Context
- `format!` macro introduces overhead of creating a new `String` object during runtime. When `concat!`, `push()` or `push_str()` is sufficient, use them instead of `format!`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
