### PR TITLE
chore: use binary units for size instead of decimal units

### DIFF
--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -117,7 +117,7 @@ impl KernelModules<'_> {
 				used_modules.pop();
 			}
 			let module_size =
-				ByteSize::b(columns[1].to_string().parse().unwrap_or(0)).to_string();
+				ByteSize::b(columns[1].parse().unwrap_or(0)).to_string_as(true);
 			module_list.push(vec![module_name, module_size, used_modules]);
 		}
 		// Reverse the kernel modules if the argument is provided.


### PR DESCRIPTION
## Description
- Use binary units for size instead of decimal units

## Motivation and Context
- In Linux, binary units are used by default instead of decimal units. For example, `ls -h` shows file sizes in abbreviation (K, M, G, T), which represents KiB, MiB, GiB, TiB respectively instead of KB, MB, GB, TB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
