### PR TITLE
feat: add support for searching kernel modules by regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Master
+### Added
+- Support for searching kernel modules by regular expression
+
 ## [1.6.5] - 2024-04-12
 ### Added
 - Add a panic hook to reset terminal upon panic by @eld4niz in [#141](https://github.com/orhun/kmon/pull/141)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +348,7 @@ dependencies = [
  "copypasta-ext",
  "enum-iterator",
  "ratatui",
+ "regex",
  "termion 4.0.0",
  "unicode-width",
 ]
@@ -411,6 +421,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -547,6 +563,35 @@ name = "redox_termios"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ colorsys = "0.6.7"
 enum-iterator = "2.0.0"
 clap = "4.5.4"
 copypasta-ext = "0.4.4"
+regex = "1.11.1"
 
 [build-dependencies]
 clap_mangen = "0.2.20"

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ kmon [OPTIONS] [COMMAND]
 -t, --tickrate <MS>         Set the refresh rate of the terminal [default: 250]
 -r, --reverse               Reverse the kernel module list
 -u, --unicode               Show Unicode symbols for the block titles
+-E, --regex                 Interpret the module search query as a regular expression
 -h, --help                  Print help information
 -V, --version               Print version information
 ```
@@ -523,6 +524,10 @@ kmon --unicode
 `-t, --tickrate` option can be used for setting the refresh interval of the terminal UI in milliseconds.
 
 ![Setting the terminal tick rate](https://user-images.githubusercontent.com/24392180/76807925-1aa7a980-67f7-11ea-9af5-bb80849f5629.gif)
+
+### Searching modules by regular expression
+
+`-E, --regex` option can be used for searching modules by regular expression.
 
 ## Roadmap
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -345,7 +345,7 @@ impl App {
 						.border_style(self.style.colored)
 						.borders(Borders::ALL)
 						.title(Span::styled(
-							&format!(
+							format!(
 								"{}{}",
 								info[0],
 								self.style.unicode.get(Symbol::Gear)

--- a/src/args.rs
+++ b/src/args.rs
@@ -68,6 +68,13 @@ pub fn get_args() -> App {
 				.help("Show Unicode symbols for the block titles")
 				.action(ArgAction::SetTrue),
 		)
+		.arg(
+			Arg::new("regex")
+				.short('E')
+				.long("regex")
+				.help("Interpret the module search query as a regular expression")
+				.action(ArgAction::SetTrue),
+		)
 		.subcommand(
 			App::new("sort")
 				.about("Sort kernel modules")

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -35,6 +35,7 @@ impl SortType {
 pub struct ListArgs {
 	sort: SortType,
 	reverse: bool,
+	regex: bool,
 }
 
 impl ListArgs {
@@ -54,7 +55,12 @@ impl ListArgs {
 			sort: sort_type,
 			reverse: args.try_get_one::<bool>("reverse").ok().flatten()
 				== Some(&true),
+			regex: args.try_get_one::<bool>("regex").ok().flatten() == Some(&true),
 		}
+	}
+
+	pub fn regex(&self) -> bool {
+		self.regex
 	}
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -61,7 +61,7 @@ pub fn exec_cmd(cmd: &str, cmd_args: &[&str]) -> Result<String, String> {
 }
 
 /// Sets up the panic hook for the terminal.
-
+///
 /// See <https://ratatui.rs/how-to/develop-apps/panic-hooks/#termion>
 pub fn setup_panic_hook() -> Result<(), Box<dyn Error>> {
 	let raw_output = io::stdout().into_raw_mode()?;


### PR DESCRIPTION
## Description
- Add support for searching kernel modules by regular expression

## Motivation and Context
- Searching modules by regular expression is very convenient, but it is current missing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):
![Screenshot_20241203_001839](https://github.com/user-attachments/assets/82f1dfb8-0ad0-44ed-823b-82181f83c981)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
