### PR TITLE
fix: use the smaller regex-lite crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ colorsys = "0.6.7"
 enum-iterator = "2.1.0"
 clap = "4.5.23"
 copypasta-ext = "0.4.4"
-regex = "1.11.1"
+regex-lite = "0.1.6"
 
 [build-dependencies]
 clap_mangen = "0.2.24"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use ratatui::widgets::{
 	Block as TuiBlock, Borders, Clear, List, ListItem, Paragraph, Row, Table, Wrap,
 };
 use ratatui::Frame;
-use regex::RegexBuilder;
+use regex_lite::RegexBuilder;
 use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 use std::sync::mpsc::Sender;


### PR DESCRIPTION
Using the regular regex crate doubles the size of the kmon binary and we probably don't need the fancy stuff it offers over the regex-lite crate, like unicode and performance.

- https://docs.rs/regex-lite/latest/regex_lite/
- https://github.com/rust-lang/regex/blob/master/regex-lite/README.md