### PR TITLE
chore: use native error messages from command output

### DIFF
--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -294,8 +294,8 @@ impl KernelModules<'_> {
 			self.current_info.stylize_data(
 				Box::leak(
 					util::exec_cmd("modinfo", &[&self.current_name])
-						.unwrap_or_else(|_| {
-							String::from("module information not available")
+						.unwrap_or_else(|e| {
+							format!("module information not available: {e}")
 						})
 						.replace("signature: ", "signature: \n")
 						.into_boxed_str(),

--- a/src/kernel/log.rs
+++ b/src/kernel/log.rs
@@ -19,7 +19,7 @@ impl KernelLogs {
 			"dmesg",
 			&["--kernel", "--human", "--ctime", "--color=never"],
 		)
-		.unwrap_or_else(|_| String::from("failed to retrieve dmesg output"));
+		.unwrap_or_else(|e| format!("failed to retrieve dmesg output: {e}"));
 		let logs_updated =
 			self.output.lines().next_back().unwrap_or_default() != self.last_line;
 		self.last_line = self


### PR DESCRIPTION
## Description
- When `dmesg` or `modinfo` returns error, we can just use their native error messages instead of custom ones. They are sometimes clearer, for example:

### Native error message from dmesg
> dmesg: read kernel buffer failed: Operation not permitted

### Custom error message in kmon
> failed to retrieve dmesg output

The first one indicates that the error is caused by "Operation not permitted", while the second one doesn't.

## Motivation and Context
Make error messages clearer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
