### PR TITLE
refactor: optimize string splitting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -246,6 +246,8 @@ impl App {
 		&mut self,
 		kernel_modules: &mut KernelModules<'_>,
 	) {
+		// If there is no space in "used_modules", return a vector with "-"
+		// Otherwise, split the modules by commas and collect them into a vector
 		let dependent_modules_list = kernel_modules.default_list
 			[kernel_modules.index][2]
 			.rsplit_once(' ')

--- a/src/app.rs
+++ b/src/app.rs
@@ -248,11 +248,8 @@ impl App {
 	) {
 		let dependent_modules_list = kernel_modules.default_list
 			[kernel_modules.index][2]
-			.split(' ')
-			.last()
-			.unwrap_or("-")
-			.split(',')
-			.collect::<Vec<&str>>();
+			.rsplit_once(' ')
+			.map_or(vec!["-"], |(_, modules)| modules.split(',').collect());
 		if !(dependent_modules_list[0] == "-"
 			|| kernel_modules.current_name.contains("Dependent modules"))
 			|| cfg!(test)

--- a/src/kernel/cmd.rs
+++ b/src/kernel/cmd.rs
@@ -1,4 +1,5 @@
 use crate::style::Symbol;
+use std::{ffi::OsStr, path::Path};
 
 /// Kernel module related command
 #[derive(Debug)]
@@ -56,7 +57,7 @@ impl ModuleCommand {
 		match self {
             Self::None => Command::new(String::from(""), "", &format!("Module: {module_name}"), Symbol::None),
             Self::Load => Command::new(
-                if Self::is_module_filename(module_name) {
+                if Self::is_module_filename(Path::new(module_name)) {
 					format!("insmod {}", &module_name)
 				} else {
 					format!("modprobe {0} || insmod {0}.ko", &module_name)
@@ -114,8 +115,8 @@ impl ModuleCommand {
 	}
 
 	/// Check if module name is a filename with suffix 'ko'
-	pub fn is_module_filename(module_name: &str) -> bool {
-		module_name.ends_with(".ko")
+	pub fn is_module_filename(module_name: &Path) -> bool {
+		module_name.extension() == Some(OsStr::new("ko"))
 	}
 }
 


### PR DESCRIPTION
## Description
Remove unnecessary calls of string splitting functions and optimize usage of string splitting methods.

## Motivation and Context
Some string splitting function calls are unnecessary, such as:
```rust
match module_name.split('.').collect::<Vec<&str>>().last() {
    Some(v) => *v == "ko",
    None => false,
}
```

Some string splitting function calls can be simplified / optimized, such as:
```rust
if title.contains('!') {
	title = (*title
		.split('!')
		.collect::<Vec<&str>>()
		.last()
		.unwrap_or(&""))
	.to_string();
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo test` passed.

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
