### PR TITLE
fix: return early if no modules exist when displaying dependent modules

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -246,34 +246,38 @@ impl App {
 		&mut self,
 		kernel_modules: &mut KernelModules<'_>,
 	) {
-		// If there is no space in "used_modules", return a vector with "-"
-		// Otherwise, split the modules by commas and collect them into a vector
-		let dependent_modules_list = kernel_modules.default_list
-			[kernel_modules.index][2]
-			.rsplit_once(' ')
-			.map_or(vec!["-"], |(_, modules)| modules.split(',').collect());
-		if !(dependent_modules_list[0] == "-"
-			|| kernel_modules.current_name.contains("Dependent modules"))
-			|| cfg!(test)
-		{
-			kernel_modules.info_scroll_offset = 0;
-			kernel_modules.command = ModuleCommand::None;
-			kernel_modules.current_name = format!(
-				"!Dependent modules of {}{}",
-				kernel_modules.current_name,
-				self.style.unicode.get(Symbol::HistoricSite)
-			);
-			let mut dependent_modules = Vec::new();
-			for module in &dependent_modules_list {
-				dependent_modules.push(Line::from(vec![
-					Span::styled("-", self.style.colored),
-					Span::styled(format!(" {module}"), self.style.default),
-				]));
+		let current_line = kernel_modules.default_list.get(kernel_modules.index);
+
+		if let Some(line) = current_line {
+			// If there is no space in "used_modules", return a vector with "-"
+			// Otherwise, split the modules by commas and collect them into a vector
+			let dependent_modules_list = line[2]
+				.rsplit_once(' ')
+				.map_or(vec!["-"], |(_, modules)| modules.split(',').collect());
+
+			if !(dependent_modules_list[0] == "-"
+				|| kernel_modules.current_name.contains("Dependent modules"))
+				|| cfg!(test)
+			{
+				kernel_modules.info_scroll_offset = 0;
+				kernel_modules.command = ModuleCommand::None;
+				kernel_modules.current_name = format!(
+					"!Dependent modules of {}{}",
+					kernel_modules.current_name,
+					self.style.unicode.get(Symbol::HistoricSite)
+				);
+				let mut dependent_modules = Vec::new();
+				for module in &dependent_modules_list {
+					dependent_modules.push(Line::from(vec![
+						Span::styled("-", self.style.colored),
+						Span::styled(format!(" {module}"), self.style.default),
+					]));
+				}
+				kernel_modules.current_info.set(
+					Text::from(dependent_modules),
+					kernel_modules.current_name.clone(),
+				);
 			}
-			kernel_modules.current_info.set(
-				Text::from(dependent_modules),
-				kernel_modules.current_name.clone(),
-			);
 		}
 	}
 


### PR DESCRIPTION
## Description
When displaying dependent modules, check whether the list is empty and return early.

## Motivation and Context
Currently, when no modules exist, pressing "D" or "Alt+D" to display dependent modules will crash the program. 

```
thread 'main' panicked at src/app.rs:250:13:
index out of bounds: the len is 0 but the index is 0
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a QEMU virtual machine, with direct kernel boot (no initramfs).

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
