### PR TITLE
fix: update bytesize to 2.0.1 to resolve SI / IEC inversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cassowary"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ratatui = { version = "0.29.0", default-features = false, features = [
   "termion",
 ] }
 termion = "4.0.3"
-bytesize = "1.3.0"
+bytesize = "2.0.1"
 unicode-width = "0.1.14"
 colorsys = "0.6.7"
 enum-iterator = "2.1.0"

--- a/src/kernel/lkm.rs
+++ b/src/kernel/lkm.rs
@@ -123,7 +123,7 @@ impl KernelModules<'_> {
 				used_modules.pop();
 			}
 			let module_size =
-				ByteSize::b(columns[1].parse().unwrap_or(0)).to_string_as(true);
+				ByteSize::b(columns[1].parse().unwrap_or(0)).to_string();
 			module_list.push(vec![module_name, module_size, used_modules]);
 		}
 		// Reverse the kernel modules if the argument is provided.


### PR DESCRIPTION
## Description
Update [bytesize](https://crates.io/crates/bytesize) to 2.0.1 to resolve SI / IEC inversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In Bytesize 1.3, the effect of `si_unit` argument in `to_string_as()` function is inverted.

Related issue: https://github.com/bytesize-rs/bytesize/issues/25

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the [documentation](https://github.com/orhun/kmon/blob/master/README.md) and [changelog](https://github.com/orhun/kmon/blob/master/CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] [Rustfmt](https://github.com/rust-lang/rustfmt) and [Rust-clippy](https://github.com/rust-lang/rust-clippy) passed.
