### PR TITLE
chore(deps): use increase-if-necessary for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    # Prefer bumping only when the existing constraint is no longer satisfied
+    # (eases packaging load for downstream distros; see #112).
+    versioning-strategy: increase-if-necessary
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
@@ -13,3 +16,4 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
## Description

Sets Dependabot `versioning-strategy: increase-if-necessary` for both the Cargo and GitHub Actions ecosystems.

## Motivation and Context

Fixes #112. Orhun invited a PR for this approach so packagers are not forced through frequent compatible-range bumps.

## How Has This Been Tested?

N/A (config-only). Verified YAML against [Dependabot versioning-strategy docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy).


Made with [Cursor](https://cursor.com)